### PR TITLE
DOCSP-21794: update atlascli instructions

### DIFF
--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -212,7 +212,7 @@ Follow These Steps
 
             From a terminal, issue the following command to import the MongoDB
             public GPG Key from
-            ``https://pgp.mongodb.com/server-5.0.asc>``.
+            ``https://pgp.mongodb.com/server-5.0.asc``.
             Replace ``5.0`` with your
             edition of MongoDB. 
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -61,6 +61,17 @@ Select an installation method below and follow the steps to install the
 
 .. tabs::
 
+   .. tab:: Homebrew
+      :tabid: Homebrew
+
+      Complete the Prerequisites
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      To install the {+atlas-cli+} using Homebrew, you must:
+
+      1. Use a MacOS or Linux operating system.
+      #. Install `Homebrew <https://brew.sh/>`__.
+
    .. tab:: Yum
       :tabid: yum
 
@@ -85,6 +96,21 @@ Follow These Steps
 .. tabs::
    :hidden:
 
+   .. tab:: Homebrew
+      :tabid: Homebrew
+
+      .. procedure::
+
+        .. step:: Install the {+atlas-cli+}.
+
+            Invoke the following ``brew`` command:
+
+            .. code-block:: sh
+
+              brew install mongodb-atlas-cli
+
+        .. include:: /includes/steps-verify-atlas-cli.rst
+
    .. tab:: Yum
       :tabid: yum    
 
@@ -97,9 +123,9 @@ Follow These Steps
                .. tab:: MongoDB Community Edition
                   :tabid: mdb-comm
 
-                  Create a ``/etc/yum.repos.d/mongodb-org-{MDB-Version}.repo`` 
+                  Create a ``/etc/yum.repos.d/mongodb-org-5.0.repo`` 
                   file so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace the placeholder ``{MDB-Version}`` with your
+                  ``yum``. Replace ``5.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -110,12 +136,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-org-{MDB-Version}]
+                           [mongodb-org-5.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{MDB-Version}/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/5.0/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc
+                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -123,20 +149,20 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-org-{MDB-Version}]
+                           [mongodb-org-5.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/{MDB-Version}/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc
+                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
                   Create a
-                  ``/etc/yum.repos.d/mongodb-enterprise-{MDB-Version}.repo`` file
+                  ``/etc/yum.repos.d/mongodb-enterprise-5.0.repo`` file
                   so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace the placeholder ``{MDB-Version}`` with your
+                  ``yum``. Replace ``5.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -147,12 +173,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-enterprise-{MDB-Version}]
+                           [mongodb-enterprise-5.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/{MDB-Version}/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/5.0/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc
+                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -160,12 +186,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-enterprise-{MDB-Version}]
+                           [mongodb-enterprise-5.0]
                            name=MongoDB Enterprise Repository
-                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/{MDB-Version}/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/5.0/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc
+                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
 
          .. step:: Install the {+atlas-cli+}.
 
@@ -186,13 +212,13 @@ Follow These Steps
 
             From a terminal, issue the following command to import the MongoDB
             public GPG Key from
-            ``https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc>``.
-            Replace the placeholder ``{MDB-Version}`` with your
+            ``https://pgp.mongodb.com/server-5.0.asc>``.
+            Replace ``5.0`` with your
             edition of MongoDB. 
 
             .. code-block:: sh
      
-               wget -qO - https://www.mongodb.org/static/pgp/server-{MDB-Version}.asc | sudo apt-key add -
+               wget -qO - https://pgp.mongodb.com/server-5.0.asc | sudo apt-key add -
      
             A successful command returns an ``OK``.
 
@@ -204,8 +230,8 @@ Follow These Steps
                   :tabid: mdb-comm
 
                   Create the list file
-                  ``/etc/apt/sources.list.d/mongodb-org-{MDB-Version}.list`` for
-                  your version of Ubuntu. Replace the placeholder ``{MDB-Version}`` with your
+                  ``/etc/apt/sources.list.d/mongodb-org-5.0.list`` for
+                  your version of Ubuntu. Replace ``5.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -215,34 +241,34 @@ Follow These Steps
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{MDB-Version} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{MDB-Version}.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
                      .. tab:: Ubuntu 18.04 (Bionic)
                         :tabid: comm-bionic
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{MDB-Version} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{MDB-Version}.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
                      .. tab:: Debian 10 (Buster)
                         :tabid: comm-deb-10
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/{MDB-Version} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{MDB-Version}.list
+                           echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
                      .. tab:: Debian 9 (Stretch)
                         :tabid: comm-deb-9
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/{MDB-Version} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{MDB-Version}.list
+                           echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
                   Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list``
-                  file for MongoDB. Replace the placeholder ``{MDB-Version}`` with your
+                  file for MongoDB. Replace ``5.0`` with your
                   edition of MongoDB.
         
                   .. tabs::
@@ -252,28 +278,36 @@ Follow These Steps
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{MDB-Version} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Ubuntu 18.04 (Bionic)
                         :tabid: ent-bionic
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{MDB-Version} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian 10 (Buster)
                         :tabid: ent-deb-10
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{MDB-Version} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian 9 (Stretch)
                         :tabid: ent-deb-9
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{MDB-Version} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
+         .. step:: Refresh the package database.
+
+            Invoke the following ``apt`` command:
+
+            .. code-block:: sh
+
+               sudo apt-get update
 
          .. step:: Install the {+atlas-cli+}.
 
@@ -339,6 +373,26 @@ method you used to install the {+atlas-cli+}:
 
 
 .. tabs::
+
+
+   .. tab:: Homebrew
+      :tabid: Homebrew
+
+      Follow These Steps
+      ~~~~~~~~~~~~~~~~~~
+
+      .. procedure::
+
+         .. step:: Update the {+atlas-cli+}.
+
+            Invoke the following ``brew`` command:
+
+            .. code-block:: sh
+
+               brew update
+               brew upgrade mongocli-atlas-cli
+
+         .. include:: /includes/steps-verify-update-atlas-cli.rst
 
    .. tab:: Yum
       :tabid: yum


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-21794)
[Stage](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-21794/install-atlas-cli/)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=624cb1580fdfea9c37bd85c6)

in addition to the changes requested in the Jira, I changed the location of the PGP keys based on https://jira.mongodb.org/browse/DOCS-15195. Did a quick curl and confirmed that the keys are available at the new location.

@sarahsimpers for visibility