### PR TITLE
(DOCSP-22150) Removes line re: need to be on access list for auth login

### DIFF
--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -156,11 +156,9 @@ from the {+atlas-cli+}.
                   There was an error fetching your organizations: Global user is
                   from outside whitelisted subnets.
                
-               To fix the conflict:
-
-               - Ensure your IP address is on the :ref:`IP access list <access-list>`.
-               - Open the :ref:`configuration file <config-toml-location>`,
-                 remove the default profile, and run ``atlas auth login`` again.
+               To fix the conflict, open the :ref:`configuration file
+               <config-toml-location>`, remove the default profile, and
+               run ``atlas auth login`` again.
 
          .. step:: Issue commands using the ``--projectId`` and ``--orgId`` flags.
 


### PR DESCRIPTION
[Build Link](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6262dfe20fdfea9c3727a32f)
[Jira Ticket Link](https://jira.mongodb.org/browse/DOCSP-22150)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22150/connect-atlas-cli/)

Removes a line from the note on how to fix potential issues with the config file. It is not necessary to be on the access list to use the atlas auth login command.