### PR TITLE
(DOCSP-22576) Adds atlas setup tutorial

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/snooty.toml
+++ b/snooty.toml
@@ -12,6 +12,7 @@ toc_landing_pages = [
   "/atlas-cli-env-variables",
   "/atlas-cli-profiles",
   "/atlas-cli-quickstart",
+  "/atlas-cli-tutorials",
   "/command/atlas",
   "/connect-atlas-cli",
   "/install-atlas-cli",
@@ -25,6 +26,8 @@ atlas-cli-full = "MongoDB Atlas CLI"
 atlas-cli-version = "1.0.3"
 cloudgov = ":atlas:`MongoDB Atlas for Government </government>`"
 cloudgov-short = "AtlasGov"
+cluster = "cluster"
+clusters = "clusters"
 data-lake = "Atlas Data Lake"
 data-lake-short = "Data Lake"
 data-lake-stores = "data stores"

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -12,25 +12,22 @@ Get Started with |service|
    :depth: 1
    :class: singlecol
 
-You can get started with |service| via the {+atlas-cli+} using a single command: ``atlas setup``.
+You can get started with |service| via the {+atlas-cli+} using a single
+command: ``atlas setup``.
 
 This tutorial demonstrates how to use ``atlas setup`` to: 
 
 1. Sign up for an |service| account.
-#. Create one |service| organization and one project.
-#. Create one cluster in your |service| project.
+#. Authenticate with the new |service| account.
+#. Create one free {+cluster+}.
 #. Load :atlas:`sample data </sample-data/available-sample-datasets/>` 
    into your |service| cluster.
 #. Add your IP address to your project's IP access list.
 #. Create a MongoDB user for your |service| cluster.
 #. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
 
-You can also run ``atlas setup`` if:
-
-- You have an |service| account, but you haven't set up an
-  organization, project, or {+cluster+}.
-- You have an |service| account and an organization/project, but you
-  haven't set up a {+cluster+}.
+You can also run ``atlas setup`` if you have an |service| account and
+an organization/project, but you haven't set up a {+cluster+}.
 
 .. _atlas-cli-onboarding-reqs:
 
@@ -52,37 +49,39 @@ Complete the following procedure to get started with |service|.
       
          atlas setup
          
-      A browser window displays the :guilabel:`Create Your Account` screen.
+      A browser window displays the :guilabel:`Create Your Account`
+      screen.
 
-      If you want to log into an existing |service| account, click :guilabel:`Log in now`.
+      If you want to log into an existing |service| account, click
+      :guilabel:`Log in now` and log in.
 
-      If you're already logged into an existing |service| account, proceed to step 3.
+      If you're already logged into an existing |service| account,
+      proceed to step 3.
 
    .. step:: Sign up and verify your account.
 
-      Enter your account information and click :guilabel:`Sign Up`. Follow the prompts to verify your email or register using third-party authentication.
+      Enter your account information and click :guilabel:`Sign Up`.
+      Follow the prompts to verify your email or register using
+      third-party authentication.
 
    .. step:: Verify your {+atlas-cli+} session.
 
-      When you reach the :guilabel:`Activation` screen, copy the verification code from the {+atlas-cli+} and paste it into the browser. Then, click :guilabel:`Confirm Authorization`.
-      
-      The browser displays :guilabel:`You're all set!`. Return to the terminal window.
+      When you reach the :guilabel:`Activation` screen, copy the
+      verification code from the {+atlas-cli+} and paste it into the
+      browser. Then, click :guilabel:`Confirm Authorization` and return
+      to the terminal window.
 
    .. step:: Choose your {+cluster+} creation settings.
 
-      After you verify your {+atlas-cli+} session, ``atlas setup`` performs the following actions:
+      After you verify your {+atlas-cli+} session, ``atlas setup``
+      creates an ``M0`` cluster. ``M0`` clusters have some operational
+      :ref:`limitations <atlas-free-tier>`.
 
-      - If you are creating a new |service| account, ``atlas setup``
-        automatically creates your first organization and project.
-      - If you were logged into an existing account, ``atlas setup``:
-  
-        - Creates your first organization and project if no
-          organization or project exists.
-        - Prompts you to select a default organization and default
-          project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
-
-      - Creates an ``M0`` cluster in |service|. ``M0``
-        clusters have some operational :ref:`limitations <atlas-free-tier>`.
+      If you logged into an existing account and had existing
+      organizations and projects, ``atlas setup`` prompts you to select
+      a default organization and default project. Select a default
+      organization and project and press
+      :guilabel:`Enter`.
 
       You can choose from the following {+cluster+} creation settings: 
       
@@ -116,7 +115,8 @@ Complete the following procedure to get started with |service|.
                .. input::
                   :language: sh
             
-                  Do you want to set up your first free database in Atlas with default settings? It's free forever! **Y**
+                  Do you want to set up your first free database in
+                  Atlas with default settings? It's free forever! **Y**
 
                .. output::
                   :language: sh
@@ -134,7 +134,9 @@ Complete the following procedure to get started with |service|.
          .. tab:: Interactive Mode
             :tabid: interactive
 
-            The command prompts you for the cluster settings and provides default options. Press :kbd:`Enter` when prompted to accept the default settings. 
+            The command prompts you for the cluster settings and
+            provides default options. Press :kbd:`Enter` when prompted
+            to accept the default settings. 
 
             .. io-code-block::
          
@@ -159,10 +161,12 @@ Complete the following procedure to get started with |service|.
 
                   [Set up your database authentication access details]
                   ? Database User Username Quickstart-2345678
-                  ? Database User Password [Press Enter to use an auto-generated password 'abcdef12345'] abcdef12345
+                  ? Database User Password [Press Enter to use an
+                  auto-generated password 'abcdef12345'] abcdef12345
 
                   [Set up your database network access details]
-                  ? Access List Entry [Press Enter to use your public IP address '192.0.2.0'] 192.0.2.0
+                  ? Access List Entry [Press Enter to use your public
+                  IP address '192.0.2.0'] 192.0.2.0
 
                  [Connect to Quickstart-9876543]
                   ? Do you want to access Quickstart-9876543 with MongoDB Shell? Yes
@@ -183,7 +187,8 @@ Complete the following procedure to get started with |service|.
 
                   Loading sample data into your cluster... [Its safe to 'Ctrl + C']
 
-                  Now you can connect to your Atlas cluster with: mongosh -u Quickstart-9876543 -p abcdef12345 mongodb+srv://quickstart-9876543.example.mongodb.net
+                  Now you can connect to your Atlas cluster with:
+                  mongosh -u Quickstart-9876543 -p abcdef12345 mongodb+srv://quickstart-9876543.example.mongodb.net
 
          .. tab:: Non-Interactive Mode
             :tabid: noninteractive
@@ -204,7 +209,9 @@ Complete the following procedure to get started with |service|.
                .. input::
                   :language: sh 
 
-                  atlas quickstart --clusterName getStarted --provider AWS --region US_EAST_1 --username testUser --password changeMe accessListIp 192.0.2.15 --skipSampleData
+                  atlas quickstart --clusterName getStarted --provider
+                  AWS --region US_EAST_1 --username testUser --password
+                  changeMe accessListIp 192.0.2.15 --skipSampleData
             
                .. output::
                   :language: sh
@@ -216,10 +223,12 @@ Complete the following procedure to get started with |service|.
                   Enter [?] on any option to get help.
 
                   [Set up your database network access details]
-                  ? Access List Entry [Press Enter to use your public IP address '192.0.2.15'] 192.0.2.15
+                  ? Access List Entry [Press Enter to use your public
+                  IP address '192.0.2.15'] 192.0.2.15
 
                   [Connect to getStarted]
-                  ? Do you want to access getStarted with MongoDB Shell? Yes
+                  ? Do you want to access getStarted with MongoDB
+                  Shell? Yes
 
                   [Summary of changes]
                   Cluster Name:                          getStarted
@@ -236,17 +245,20 @@ Complete the following procedure to get started with |service|.
                   Creating your cluster... [Its safe to 'Ctrl + C']
 
 
-                  Now you can connect to your |service| cluster with: mongosh -u testUser -p changeMe mongodb+srv://getStarted.example.mongodb.net
+                  Now you can connect to your |service| cluster with:
+                  mongosh -u testUser -p changeMe mongodb+srv://getStarted.example.mongodb.net
 
 .. _atlas-cli-onboarding-summary:
 
 Take the Next Steps
 -------------------
 
-Congratulations! You have successfully created a cluster to host your
-data. 
+Congratulations! You have successfully set up your |service| account.
 
-Use the :manual:`connection string </reference/connection-string/#connection-string-options>` 
-to connect to your cluster through {+mongosh+} or your application.
+Use the :manual:`connection string 
+</reference/connection-string/#connection-string-options>` 
+that the {+atlas-cli+} provides to connect to your cluster through 
+{+mongosh+}.
 
-To view the status of your cluster, run the :ref:`atlas-clusters` command.
+To view the status of your cluster, run the :ref:`atlas-clusters`
+command.

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -77,7 +77,7 @@ Complete the following procedure to get started with |service|.
       creates an ``M0`` cluster. ``M0`` clusters have some operational
       :ref:`limitations <atlas-free-tier>`.
 
-      If you logged into an existing account and had existing
+      If you log into an existing account and have existing
       organizations and projects, ``atlas setup`` prompts you to select
       a default organization and default project. Select a default
       organization and project and press
@@ -114,8 +114,6 @@ Complete the following procedure to get started with |service|.
             Database User Username: Cluster9876543
             Database User Password: abcdef12345
 
-            Connection string: mongosh -u Cluster-9876543 -p abcdef12345 mongod
-
             Creating your cluster... [Its safe to 'Ctrl + C']
 
 
@@ -126,10 +124,8 @@ Take the Next Steps
 
 Congratulations! You have successfully set up your |service| account.
 
-Use the :manual:`connection string 
-</reference/connection-string/#connection-string-options>` 
-that the {+atlas-cli+} provides to connect to your cluster through 
-{+mongosh+}.
+Use the :manual:`connection string </reference/connection-string/#connection-string-options>` 
+to connect to your cluster through {+mongosh+} or your application.
 
 To view the status of your cluster, run the :ref:`atlas-clusters`
 command.

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -19,12 +19,13 @@ This tutorial demonstrates how to use ``atlas setup`` to:
 
 1. Sign up for an |service| account.
 #. Authenticate with the new |service| account.
-#. Create one free {+cluster+}.
+#. Create one free database.
 #. Load :atlas:`sample data </sample-data/available-sample-datasets/>` 
-   into your |service| cluster.
+   into your |service| database.
 #. Add your IP address to your project's IP access list.
-#. Create a MongoDB user for your |service| cluster.
-#. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
+#. Create a MongoDB user for your |service| {+database-deployment+}.
+#. Connect to your new {+database-deployment+} using the MongoDB Shell,
+   {+mongosh+}.
 
 You can also run ``atlas setup`` if you have an |service| account and
 an organization/project but you haven't set up a {+cluster+}.

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -34,8 +34,8 @@ You can also run ``atlas setup`` if:
 
 .. _atlas-cli-onboarding-reqs:
 
-Prerequisites 
--------------
+Complete The Prerequisites 
+--------------------------
 
 Before you begin, you must :ref:`install the {+atlas-cli+}<install-atlas-cli>`. 
 
@@ -70,17 +70,19 @@ Complete the following procedure to get started with |service|.
 
    .. step:: Choose your {+cluster+} creation settings.
 
-      ``atlas setup`` performs the following actions after you verify your {+atlas-cli+} session:
+      After you verify your {+atlas-cli+} session, ``atlas setup`` performs the following actions:
 
-      a. If you are creating a new |service| account, ``atlas setup``
-         automatically creates your first organization and project.
-      b. If you were logged into an existing account, ``atlas setup``:
-         - Creates your first organization and project if no
-           organization or project exists.
-         - Prompts you to select a default organization and default
-           project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
-      c. Creates an ``M0`` cluster in |service|. ``M0``
-         clusters have some operational :ref:`limitations <atlas-free-tier>`.
+      - If you are creating a new |service| account, ``atlas setup``
+        automatically creates your first organization and project.
+      - If you were logged into an existing account, ``atlas setup``:
+  
+        - Creates your first organization and project if no
+          organization or project exists.
+        - Prompts you to select a default organization and default
+          project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
+
+      - Creates an ``M0`` cluster in |service|. ``M0``
+        clusters have some operational :ref:`limitations <atlas-free-tier>`.
 
       You can choose from the following {+cluster+} creation settings: 
       
@@ -95,7 +97,9 @@ Complete the following procedure to get started with |service|.
          .. tab:: Default Settings Mode
             :tabid: default
 
-            When the {+atlas-cli+} prompts ``Do you want to set up your first free database in Atlas with default settings? It's free forever!``, enter :guilabel:`Y`.
+            When the {+atlas-cli+} prompts ``Do you want to set up``
+            ``your first free database in Atlas with default``
+            ``settings? It's free forever!``, enter :guilabel:`Y`.
             
             The command creates a sample ``M0`` shared-tier cluster with the 
             following default settings:
@@ -140,7 +144,6 @@ Complete the following procedure to get started with |service|.
                   atlas quickstart 
 
                .. output::
-                  :language: sh
 
                   You are creating a new Atlas cluster and enabling access to it.
 
@@ -246,4 +249,4 @@ data.
 Use the :manual:`connection string </reference/connection-string/#connection-string-options>` 
 to connect to your cluster through {+mongosh+} or your application.
 
-To view the status of your cluster, run an ``atlas clusters`` command in the {+atlas-cli+}.
+To view the status of your cluster, run the :ref:`atlas-clusters` command.

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -27,7 +27,7 @@ This tutorial demonstrates how to use ``atlas setup`` to:
 #. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
 
 You can also run ``atlas setup`` if you have an |service| account and
-an organization/project, but you haven't set up a {+cluster+}.
+an organization/project but you haven't set up a {+cluster+}.
 
 .. _atlas-cli-onboarding-reqs:
 
@@ -49,7 +49,7 @@ Complete the following procedure to get started with |service|.
       
          atlas setup
          
-      A browser window displays the :guilabel:`Create Your Account`
+      After you run the command, enter :guilabel:`Y` to open the default browser. A browser window displays the :guilabel:`Create Your Account`
       screen.
 
       If you want to log into an existing |service| account, click
@@ -71,7 +71,7 @@ Complete the following procedure to get started with |service|.
       browser. Then, click :guilabel:`Confirm Authorization` and return
       to the terminal window.
 
-   .. step:: Choose your {+cluster+} creation settings.
+   .. step:: Accept the default {+cluster+} creation settings.
 
       After you verify your {+atlas-cli+} session, ``atlas setup``
       creates an ``M0`` cluster. ``M0`` clusters have some operational
@@ -82,171 +82,42 @@ Complete the following procedure to get started with |service|.
       a default organization and default project. Select a default
       organization and project and press
       :guilabel:`Enter`.
-
-      You can choose from the following {+cluster+} creation settings: 
       
-      - **Default settings mode**: the command creates a sample shared-tier cluster with the default settings.
-      - **Interactive mode**: the command prompts you for the cluster settings and provides default values. 
-      - **Noninteractive mode**: you run the command with the options.
-      
-      Click the tab to see next steps for your preferred mode. 
-  
-      .. tabs:: 
-
-         .. tab:: Default Settings Mode
-            :tabid: default
-
-            When the {+atlas-cli+} prompts ``Do you want to set up``
-            ``your first free database in Atlas with default``
-            ``settings? It's free forever!``, enter :guilabel:`Y`.
+      When the {+atlas-cli+} prompts ``Do you want to set up``
+      ``your first free database in Atlas with default``
+      ``settings? It's free forever!``, enter :guilabel:`Y` to create your {+cluster+} with the default settings.
             
-            The command creates a sample ``M0`` shared-tier cluster with the 
-            following default settings:
+      The command creates a sample ``M0`` shared-tier cluster with the 
+      following default settings:
  
-            - Cluster name: ``Cluster<number>``
-            - Cloud provider and region: ``AWS - US_EAST_1``
-            - Database Username: ``Cluster<number>``
-            - Database User Password: ``abcdef12345``
-            - Load Sample Data: ``Yes``
-            - Allow connection from IP: ``<YourIPAddress>``
+      - Cluster name: ``Cluster<number>``
+      - Cloud provider and region: ``AWS - US_EAST_1``
+      - Database Username: ``Cluster<number>``
+      - Database User Password: ``abcdef12345``
+      - Load Sample Data: ``Yes``
+      - Allow connection from IP: ``<YourIPAddress>``
   
-            .. io-code-block::
+      .. io-code-block::
          
-               .. input::
-                  :language: sh
+         .. input::
+            :language: sh
             
-                  Do you want to set up your first free database in
-                  Atlas with default settings? It's free forever! **Y**
+            Do you want to set up your first free database in
+            Atlas with default settings? It's free forever! Y
 
-               .. output::
-                  :language: sh
+         .. output::
+            :language: sh
 
-                  We are deploying Cluster9876543...
+            We are deploying Cluster9876543...
 
-                  Please store your database authentication access details in a secure location.
-                  Database User Username: Cluster9876543
-                  Database User Password: abcdef12345
+            Please store your database authentication access details in a secure location.
+            Database User Username: Cluster9876543
+            Database User Password: abcdef12345
 
-                  Connection string: mongosh -u Cluster-9876543 -p abcdef12345 mongod
+            Connection string: mongosh -u Cluster-9876543 -p abcdef12345 mongod
 
-                  Creating your cluster... [Its safe to 'Ctrl + C']
+            Creating your cluster... [Its safe to 'Ctrl + C']
 
-         .. tab:: Interactive Mode
-            :tabid: interactive
-
-            The command prompts you for the cluster settings and
-            provides default options. Press :kbd:`Enter` when prompted
-            to accept the default settings. 
-
-            .. io-code-block::
-         
-               .. input::
-                  :language: sh
-            
-                  atlas quickstart 
-
-               .. output::
-
-                  You are creating a new Atlas cluster and enabling access to it.
-
-                  Press [Enter] to use the default values.
-
-                  Enter [?] on any option to get help.
-
-                  [Set up your Atlas cluster]
-                  ? Cluster Name [This cant be changed later] Quickstart-9876543
-                  ? Cloud Provider AWS
-                  ? Cloud Provider Region US_EAST_1
-                  ? Do you want to load sample data into Quickstart-9876543? Yes
-
-                  [Set up your database authentication access details]
-                  ? Database User Username Quickstart-2345678
-                  ? Database User Password [Press Enter to use an
-                  auto-generated password 'abcdef12345'] abcdef12345
-
-                  [Set up your database network access details]
-                  ? Access List Entry [Press Enter to use your public
-                  IP address '192.0.2.0'] 192.0.2.0
-
-                 [Connect to Quickstart-9876543]
-                  ? Do you want to access Quickstart-9876543 with MongoDB Shell? Yes
-
-                  [Summary of changes]
-                  Cluster Name:                          Quickstart-9876543
-                  Cluster Tier:                          M0
-                  Cloud Provider:                        AWS
-                  Region:                                US_EAST_1
-                  Cluster Disk Size (GiB):               0.5
-                  Database Username:                     Quickstart-9876543
-                  Allow connections from (IP Address):   192.0.2.0
-                  Load sample data:                      Yes
-                  Open shell:                            No
-                  ? Do you want to create a new cluster Quickstart-9876543 with the following settings? Yes
-                  We are deploying Quickstart-9876543...
-                  Creating your cluster... [Its safe to 'Ctrl + C']
-
-                  Loading sample data into your cluster... [Its safe to 'Ctrl + C']
-
-                  Now you can connect to your Atlas cluster with:
-                  mongosh -u Quickstart-9876543 -p abcdef12345 mongodb+srv://quickstart-9876543.example.mongodb.net
-
-         .. tab:: Non-Interactive Mode
-            :tabid: noninteractive
-      
-            The command creates a sample shared-tier cluster with the 
-            following settings:
-      
-            - Cluster name: ``getStarted``
-            - Service provider: ``AWS``
-            - Provider region: ``US_EAST-1``
-            - Cluster tier: ``M0``
-            - Disk size: ``2`` GB
-            - MongoDB version: ``5.0``
-            - Replica set members: ``3``
-      
-            .. io-code-block::
-
-               .. input::
-                  :language: sh 
-
-                  atlas quickstart --clusterName getStarted --provider
-                  AWS --region US_EAST_1 --username testUser --password
-                  changeMe accessListIp 192.0.2.15 --skipSampleData
-            
-               .. output::
-                  :language: sh
-
-                  You are creating a new Atlas cluster and enabling access to it.
-
-                  Press [Enter] to use the default values.
-
-                  Enter [?] on any option to get help.
-
-                  [Set up your database network access details]
-                  ? Access List Entry [Press Enter to use your public
-                  IP address '192.0.2.15'] 192.0.2.15
-
-                  [Connect to getStarted]
-                  ? Do you want to access getStarted with MongoDB
-                  Shell? Yes
-
-                  [Summary of changes]
-                  Cluster Name:                          getStarted
-                  Cluster Tier:                          M0
-                  Cloud Provider:                        AWS
-                  Region:                                US_EAST_1
-                  Cluster Disk Size (GiB):               0.5
-                  Database Username:                     testUser
-                  Allow connections from (IP Address):   192.0.2.15
-                  Load sample data:                      No
-                  Open shell:                            No
-                  ? Do you want to create a new cluster getStarted with the following settings? Yes
-                  We are deploying getStarted...
-                  Creating your cluster... [Its safe to 'Ctrl + C']
-
-
-                  Now you can connect to your |service| cluster with:
-                  mongosh -u testUser -p changeMe mongodb+srv://getStarted.example.mongodb.net
 
 .. _atlas-cli-onboarding-summary:
 

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -1,8 +1,8 @@
 .. _atlas-cli-onboarding:
 
-===============================================
-Get Started with |service| with ``atlas setup``
-===============================================
+==========================
+Get Started with |service|
+==========================
 
 .. default-domain:: mongodb
 
@@ -12,10 +12,12 @@ Get Started with |service| with ``atlas setup``
    :depth: 1
    :class: singlecol
 
-This tutorial demonstrates how to use the ``atlas setup`` command to: 
+You can get started with |service| via the {+atlas-cli+} using a single command: ``atlas setup``.
+
+This tutorial demonstrates how to use ``atlas setup`` to: 
 
 1. Sign up for an |service| account.
-#. Create one |service| organization project.
+#. Create one |service| organization and one project.
 #. Create one cluster in your |service| project.
 #. Load :atlas:`sample data </sample-data/available-sample-datasets/>` 
    into your |service| cluster.
@@ -52,29 +54,33 @@ Complete the following procedure to get started with |service|.
          
       A browser window displays the :guilabel:`Create Your Account` screen.
 
-      If you are already logged into an |service| account, ``atlas setup`` performs one of hte following actions:
+      If you want to log into an existing |service| account, click :guilabel:`Log in now`.
 
-      - Creates your first organization and project if no organization
-        or project exists.
-      - Prompts you to select a default organization and default
-        project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
-
-      If you are already logged into an existing |service| account, proceed to step 4.
+      If you're already logged into an existing |service| account, proceed to step 3.
 
    .. step:: Sign up and verify your account.
 
       Enter your account information and click :guilabel:`Sign Up`. Follow the prompts to verify your email or register using third-party authentication.
 
-      |service| automatically creates your first organization and project.
-
    .. step:: Verify your {+atlas-cli+} session.
 
-      When you reach the :guilabel:`Paste or enter {+atlas-cli+} verification code` screen, copy the verification code from the {+atlas-cli+} and paste it into the browser. Then, click :guilabel:`Confirm Authorization` and return to the terminal window.
+      When you reach the :guilabel:`Activation` screen, copy the verification code from the {+atlas-cli+} and paste it into the browser. Then, click :guilabel:`Confirm Authorization`.
+      
+      The browser displays :guilabel:`You're all set!`. Return to the terminal window.
 
    .. step:: Choose your {+cluster+} creation settings.
 
-      ``atlas setup`` creates an ``M0`` cluster in |service|. ``M0``
-      clusters have some operational :ref:`limitations <atlas-free-tier>`.
+      ``atlas setup`` performs the following actions after you verify your {+atlas-cli+} session:
+
+      a. If you are creating a new |service| account, ``atlas setup``
+         automatically creates your first organization and project.
+      b. If you were logged into an existing account, ``atlas setup``:
+         - Creates your first organization and project if no
+           organization or project exists.
+         - Prompts you to select a default organization and default
+           project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
+      c. Creates an ``M0`` cluster in |service|. ``M0``
+         clusters have some operational :ref:`limitations <atlas-free-tier>`.
 
       You can choose from the following {+cluster+} creation settings: 
       

--- a/source/atlas-cli-getting-started.txt
+++ b/source/atlas-cli-getting-started.txt
@@ -1,0 +1,243 @@
+.. _atlas-cli-onboarding:
+
+===============================================
+Get Started with |service| with ``atlas setup``
+===============================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+This tutorial demonstrates how to use the ``atlas setup`` command to: 
+
+1. Sign up for an |service| account.
+#. Create one |service| organization project.
+#. Create one cluster in your |service| project.
+#. Load :atlas:`sample data </sample-data/available-sample-datasets/>` 
+   into your |service| cluster.
+#. Add your IP address to your project's IP access list.
+#. Create a MongoDB user for your |service| cluster.
+#. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
+
+You can also run ``atlas setup`` if:
+
+- You have an |service| account, but you haven't set up an
+  organization, project, or {+cluster+}.
+- You have an |service| account and an organization/project, but you
+  haven't set up a {+cluster+}.
+
+.. _atlas-cli-onboarding-reqs:
+
+Prerequisites 
+-------------
+
+Before you begin, you must :ref:`install the {+atlas-cli+}<install-atlas-cli>`. 
+
+Follow These Steps
+------------------
+
+Complete the following procedure to get started with |service|.
+
+.. procedure::
+
+   .. step:: Run the ``atlas setup`` command in the terminal.
+
+      .. code-block:: sh
+      
+         atlas setup
+         
+      A browser window displays the :guilabel:`Create Your Account` screen.
+
+      If you are already logged into an |service| account, ``atlas setup`` performs one of hte following actions:
+
+      - Creates your first organization and project if no organization
+        or project exists.
+      - Prompts you to select a default organization and default
+        project if you have existing organizations and projects. Select a default organization and project and press :guilabel:`Enter`.
+
+      If you are already logged into an existing |service| account, proceed to step 4.
+
+   .. step:: Sign up and verify your account.
+
+      Enter your account information and click :guilabel:`Sign Up`. Follow the prompts to verify your email or register using third-party authentication.
+
+      |service| automatically creates your first organization and project.
+
+   .. step:: Verify your {+atlas-cli+} session.
+
+      When you reach the :guilabel:`Paste or enter {+atlas-cli+} verification code` screen, copy the verification code from the {+atlas-cli+} and paste it into the browser. Then, click :guilabel:`Confirm Authorization` and return to the terminal window.
+
+   .. step:: Choose your {+cluster+} creation settings.
+
+      ``atlas setup`` creates an ``M0`` cluster in |service|. ``M0``
+      clusters have some operational :ref:`limitations <atlas-free-tier>`.
+
+      You can choose from the following {+cluster+} creation settings: 
+      
+      - **Default settings mode**: the command creates a sample shared-tier cluster with the default settings.
+      - **Interactive mode**: the command prompts you for the cluster settings and provides default values. 
+      - **Noninteractive mode**: you run the command with the options.
+      
+      Click the tab to see next steps for your preferred mode. 
+  
+      .. tabs:: 
+
+         .. tab:: Default Settings Mode
+            :tabid: default
+
+            When the {+atlas-cli+} prompts ``Do you want to set up your first free database in Atlas with default settings? It's free forever!``, enter :guilabel:`Y`.
+            
+            The command creates a sample ``M0`` shared-tier cluster with the 
+            following default settings:
+ 
+            - Cluster name: ``Cluster<number>``
+            - Cloud provider and region: ``AWS - US_EAST_1``
+            - Database Username: ``Cluster<number>``
+            - Database User Password: ``abcdef12345``
+            - Load Sample Data: ``Yes``
+            - Allow connection from IP: ``<YourIPAddress>``
+  
+            .. io-code-block::
+         
+               .. input::
+                  :language: sh
+            
+                  Do you want to set up your first free database in Atlas with default settings? It's free forever! **Y**
+
+               .. output::
+                  :language: sh
+
+                  We are deploying Cluster9876543...
+
+                  Please store your database authentication access details in a secure location.
+                  Database User Username: Cluster9876543
+                  Database User Password: abcdef12345
+
+                  Connection string: mongosh -u Cluster-9876543 -p abcdef12345 mongod
+
+                  Creating your cluster... [Its safe to 'Ctrl + C']
+
+         .. tab:: Interactive Mode
+            :tabid: interactive
+
+            The command prompts you for the cluster settings and provides default options. Press :kbd:`Enter` when prompted to accept the default settings. 
+
+            .. io-code-block::
+         
+               .. input::
+                  :language: sh
+            
+                  atlas quickstart 
+
+               .. output::
+                  :language: sh
+
+                  You are creating a new Atlas cluster and enabling access to it.
+
+                  Press [Enter] to use the default values.
+
+                  Enter [?] on any option to get help.
+
+                  [Set up your Atlas cluster]
+                  ? Cluster Name [This cant be changed later] Quickstart-9876543
+                  ? Cloud Provider AWS
+                  ? Cloud Provider Region US_EAST_1
+                  ? Do you want to load sample data into Quickstart-9876543? Yes
+
+                  [Set up your database authentication access details]
+                  ? Database User Username Quickstart-2345678
+                  ? Database User Password [Press Enter to use an auto-generated password 'abcdef12345'] abcdef12345
+
+                  [Set up your database network access details]
+                  ? Access List Entry [Press Enter to use your public IP address '192.0.2.0'] 192.0.2.0
+
+                 [Connect to Quickstart-9876543]
+                  ? Do you want to access Quickstart-9876543 with MongoDB Shell? Yes
+
+                  [Summary of changes]
+                  Cluster Name:                          Quickstart-9876543
+                  Cluster Tier:                          M0
+                  Cloud Provider:                        AWS
+                  Region:                                US_EAST_1
+                  Cluster Disk Size (GiB):               0.5
+                  Database Username:                     Quickstart-9876543
+                  Allow connections from (IP Address):   192.0.2.0
+                  Load sample data:                      Yes
+                  Open shell:                            No
+                  ? Do you want to create a new cluster Quickstart-9876543 with the following settings? Yes
+                  We are deploying Quickstart-9876543...
+                  Creating your cluster... [Its safe to 'Ctrl + C']
+
+                  Loading sample data into your cluster... [Its safe to 'Ctrl + C']
+
+                  Now you can connect to your Atlas cluster with: mongosh -u Quickstart-9876543 -p abcdef12345 mongodb+srv://quickstart-9876543.example.mongodb.net
+
+         .. tab:: Non-Interactive Mode
+            :tabid: noninteractive
+      
+            The command creates a sample shared-tier cluster with the 
+            following settings:
+      
+            - Cluster name: ``getStarted``
+            - Service provider: ``AWS``
+            - Provider region: ``US_EAST-1``
+            - Cluster tier: ``M0``
+            - Disk size: ``2`` GB
+            - MongoDB version: ``5.0``
+            - Replica set members: ``3``
+      
+            .. io-code-block::
+
+               .. input::
+                  :language: sh 
+
+                  atlas quickstart --clusterName getStarted --provider AWS --region US_EAST_1 --username testUser --password changeMe accessListIp 192.0.2.15 --skipSampleData
+            
+               .. output::
+                  :language: sh
+
+                  You are creating a new Atlas cluster and enabling access to it.
+
+                  Press [Enter] to use the default values.
+
+                  Enter [?] on any option to get help.
+
+                  [Set up your database network access details]
+                  ? Access List Entry [Press Enter to use your public IP address '192.0.2.15'] 192.0.2.15
+
+                  [Connect to getStarted]
+                  ? Do you want to access getStarted with MongoDB Shell? Yes
+
+                  [Summary of changes]
+                  Cluster Name:                          getStarted
+                  Cluster Tier:                          M0
+                  Cloud Provider:                        AWS
+                  Region:                                US_EAST_1
+                  Cluster Disk Size (GiB):               0.5
+                  Database Username:                     testUser
+                  Allow connections from (IP Address):   192.0.2.15
+                  Load sample data:                      No
+                  Open shell:                            No
+                  ? Do you want to create a new cluster getStarted with the following settings? Yes
+                  We are deploying getStarted...
+                  Creating your cluster... [Its safe to 'Ctrl + C']
+
+
+                  Now you can connect to your |service| cluster with: mongosh -u testUser -p changeMe mongodb+srv://getStarted.example.mongodb.net
+
+.. _atlas-cli-onboarding-summary:
+
+Take the Next Steps
+-------------------
+
+Congratulations! You have successfully created a cluster to host your
+data. 
+
+Use the :manual:`connection string </reference/connection-string/#connection-string-options>` 
+to connect to your cluster through {+mongosh+} or your application.
+
+To view the status of your cluster, run an ``atlas clusters`` command in the {+atlas-cli+}.

--- a/source/atlas-cli-quickstart.txt
+++ b/source/atlas-cli-quickstart.txt
@@ -21,7 +21,8 @@ This tutorial demonstrates how to use the ``atlas quickstart`` command to:
 #. Create a MongoDB user for your |service| cluster.
 #. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
 
-To create a new |service| account or onboard an existing account that doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
+To create a new |service| account or onboard an existing account that
+doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
 
 .. _atlas-cli-quick-start-reqs:
 

--- a/source/atlas-cli-quickstart.txt
+++ b/source/atlas-cli-quickstart.txt
@@ -21,6 +21,8 @@ This tutorial demonstrates how to use the ``atlas quickstart`` command to:
 #. Create a MongoDB user for your |service| cluster.
 #. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
 
+To create a new |service| account or onboard an existing account that doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
+
 .. _atlas-cli-quick-start-reqs:
 
 Prerequisites 

--- a/source/atlas-cli-quickstart.txt
+++ b/source/atlas-cli-quickstart.txt
@@ -1,8 +1,8 @@
 .. _atlas-cli-quick-start:
 
-==========================================
-Set Up |service| with ``atlas quickstart``
-==========================================
+=========================================
+Create and Configure an |service| Cluster
+=========================================
 
 .. default-domain:: mongodb
 
@@ -17,12 +17,12 @@ This tutorial demonstrates how to use the ``atlas quickstart`` command to:
 1. Create one cluster in your |service| project.
 #. Load :atlas:`sample data </sample-data/available-sample-datasets/>` 
    into your |service| cluster.
-#. Add your IP address to your project's IP access list .
+#. Add your IP address to your project's IP access list.
 #. Create a MongoDB user for your |service| cluster.
 #. Connect to your new cluster using the MongoDB Shell, {+mongosh+}.
 
-To create a new |service| account or onboard an existing account that
-doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
+To perform all of these steps while also creating a new |service|
+account, see :ref:`atlas-cli-onboarding`.
 
 .. _atlas-cli-quick-start-reqs:
 

--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -1,0 +1,23 @@
+:noprevnext:
+.. _atlas-cli-tutorials:
+
+=======================
+{+atlas-cli+} Tutorials
+=======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Use the following tutorials to learn how to use {+atlas-cli+} commands.
+
+If you're new to |service| and want to set up an account, see :ref:`atlas-cli-onboarding`.
+
+.. toctree::
+   :titlesonly:
+
+   /atlas-cli-quickstart

--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -1,9 +1,9 @@
 :noprevnext:
 .. _atlas-cli-tutorials:
 
-===========================
-Learn from Guided Tutorials
-===========================
+=======================================
+Manage |service| from the {+atlas-cli+}
+=======================================
 
 .. default-domain:: mongodb
 
@@ -13,11 +13,14 @@ Learn from Guided Tutorials
    :depth: 1
    :class: singlecol
 
-Use the following tutorials to learn how to learn more about 
-{+atlas-cli+} commands. To learn the basics, see :ref:`install-atlas-cli` and :ref:`connect-atlas-cli`.
+Use the following tutorials to learn how to manage |service| using the 
+{+atlas-cli+}. 
+
+To learn the {+atlas-cli+} basics, see :ref:`install-atlas-cli` and :ref:`connect-atlas-cli`.
+
+You can also go straight to the :doc:`{+atlas-cli+} Commands </command/atlas>`.
 
 .. list-table:: 
-
    :header-rows: 1
    :widths: 40 60
 
@@ -36,4 +39,5 @@ Use the following tutorials to learn how to learn more about
 .. toctree::
    :titlesonly:
 
+   /atlas-cli-getting-started
    /atlas-cli-quickstart

--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -1,4 +1,3 @@
-:noprevnext:
 .. _atlas-cli-tutorials:
 
 =======================================
@@ -16,9 +15,11 @@ Manage |service| from the {+atlas-cli+}
 Use the following tutorials to learn how to manage |service| using the 
 {+atlas-cli+}. 
 
-To learn the {+atlas-cli+} basics, see :ref:`install-atlas-cli` and :ref:`connect-atlas-cli`.
+To learn the {+atlas-cli+} basics, see :ref:`install-atlas-cli` and
+:ref:`connect-atlas-cli`.
 
-You can also go straight to the :doc:`{+atlas-cli+} Commands </command/atlas>`.
+You can also go straight to the :doc:`{+atlas-cli+} Commands 
+</command/atlas>`.
 
 .. list-table:: 
    :header-rows: 1
@@ -29,12 +30,14 @@ You can also go straight to the :doc:`{+atlas-cli+} Commands </command/atlas>`.
 
    * - :ref:`atlas-cli-onboarding`
      - Use the ``atlas setup`` command to onboard with |service|,
-       including creating your account and creating your first 
-       organization, project, and {+cluster+}. You can also use this tutorial to create your first {+cluster+} even if you already have an |service| account, organzation, and project.
+       including creating your account and {+cluster+}. You can also
+       use this tutorial to create your first {+cluster+} even if you
+       already have an |service| account.
 
    * - :ref:`atlas-cli-quick-start`
      - Use the ``atlas quickstart`` command to create your first 
-       {+cluster+}. This tutorial requires an |service| account and an existing organization.
+       {+cluster+}. This tutorial requires an |service| account and an
+       existing organization.
 
 .. toctree::
    :titlesonly:

--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -1,9 +1,9 @@
 :noprevnext:
 .. _atlas-cli-tutorials:
 
-=======================
-{+atlas-cli+} Tutorials
-=======================
+===========================
+Learn from Guided Tutorials
+===========================
 
 .. default-domain:: mongodb
 
@@ -13,9 +13,25 @@
    :depth: 1
    :class: singlecol
 
-Use the following tutorials to learn how to use {+atlas-cli+} commands.
+Use the following tutorials to learn how to learn more about 
+{+atlas-cli+} commands. To learn the basics, see :ref:`install-atlas-cli` and :ref:`connect-atlas-cli`.
 
-If you're new to |service| and want to set up an account, see :ref:`atlas-cli-onboarding`.
+.. list-table:: 
+
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Tutorial
+     - Objective
+
+   * - :ref:`atlas-cli-onboarding`
+     - Use the ``atlas setup`` command to onboard with |service|,
+       including creating your account and creating your first 
+       organization, project, and {+cluster+}. You can also use this tutorial to create your first {+cluster+} even if you already have an |service| account, organzation, and project.
+
+   * - :ref:`atlas-cli-quick-start`
+     - Use the ``atlas quickstart`` command to create your first 
+       {+cluster+}. This tutorial requires an |service| account and an existing organization.
 
 .. toctree::
    :titlesonly:

--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -24,7 +24,8 @@ When you connect to an existing |service| account from the
    configuration file. Your |api| keys are like passwords. 
    Ensure that you secure the configuration file appropriately.
 
-To create a new |service| account or onboard an existing account that doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
+To create a new |service| account or onboard an existing account that
+doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
 
 Select a use case below to learn more about the available connection
 options:

--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -13,8 +13,8 @@ Connect from the {+atlas-cli+}
 Select a Connection Method
 --------------------------
 
-When you connect to |service| from the {+atlas-cli+}, you can authenticate with
-one of the following commands:
+When you connect to an existing |service| account from the 
+{+atlas-cli+}, you can authenticate with one of the following commands:
 
 .. include:: /includes/list-table-atlas-cli-auth.rst
 
@@ -24,7 +24,10 @@ one of the following commands:
    configuration file. Your |api| keys are like passwords. 
    Ensure that you secure the configuration file appropriately.
 
-Select a use case below to learn more about the available options:
+To create a new |service| account or onboard an existing account that doesn't have any {+clusters+}, see :ref:`atlas-cli-onboarding`.
+
+Select a use case below to learn more about the available connection
+options:
 
 .. tabs::
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -28,14 +28,13 @@ Follow these steps to get started using the {+atlas-cli+}:
 1. :ref:`Install the {+atlas-cli+} <install-atlas-cli>`
 2. :ref:`Connect from the {+atlas-cli+} <connect-atlas-cli>`
 3. :ref:`atlas-cli-tutorials` or :doc:`Go straight to the 
-   {+atlas-cli+}commands </command/atlas>`
+   {+atlas-cli+} commands </command/atlas>`
 
 .. toctree::
    :titlesonly:
 
    Overview </index>
    /install-atlas-cli
-   /atlas-cli-getting-started
    /connect-atlas-cli
    /atlas-cli-tutorials
    Atlas CLI Commands </command/atlas>

--- a/source/index.txt
+++ b/source/index.txt
@@ -27,7 +27,7 @@ Follow these steps to get started using the {+atlas-cli+}:
 
 1. :ref:`Install the {+atlas-cli+} <install-atlas-cli>`
 2. :ref:`Connect from the {+atlas-cli+} <connect-atlas-cli>`
-3. :ref:`See tutorials to manage Atlas from the {+atlas-cli+
+3. :ref:`See tutorials to manage Atlas from the {+atlas-cli+}
    <atlas-cli-tutorials>` or 
    :doc:`Go straight to the {+atlas-cli+} commands </command/atlas>`
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -27,8 +27,9 @@ Follow these steps to get started using the {+atlas-cli+}:
 
 1. :ref:`Install the {+atlas-cli+} <install-atlas-cli>`
 2. :ref:`Connect from the {+atlas-cli+} <connect-atlas-cli>`
-3. :ref:`atlas-cli-tutorials` or :doc:`Go straight to the 
-   {+atlas-cli+} commands </command/atlas>`
+3. :ref:`See tutorials to manage Atlas from the {+atlas-cli+
+   <atlas-cli-tutorials>` or 
+   :doc:`Go straight to the {+atlas-cli+} commands </command/atlas>`
 
 .. toctree::
    :titlesonly:

--- a/source/index.txt
+++ b/source/index.txt
@@ -33,8 +33,9 @@ Follow these steps to get started using the {+atlas-cli+}:
    :titlesonly:
 
    Overview </index>
+   /atlas-cli-getting-started
    /install-atlas-cli
    /connect-atlas-cli
-   /atlas-cli-quickstart
+   /atlas-cli-tutorials
    Atlas CLI Commands </command/atlas>
    /atlas-cli-changelog

--- a/source/index.txt
+++ b/source/index.txt
@@ -27,14 +27,15 @@ Follow these steps to get started using the {+atlas-cli+}:
 
 1. :ref:`Install the {+atlas-cli+} <install-atlas-cli>`
 2. :ref:`Connect from the {+atlas-cli+} <connect-atlas-cli>`
-3. :doc:`Learn the {+atlas-cli+} commands </command/atlas>`
+3. :ref:`atlas-cli-tutorials` or :doc:`Go straight to the 
+   {+atlas-cli+}commands </command/atlas>`
 
 .. toctree::
    :titlesonly:
 
    Overview </index>
-   /atlas-cli-getting-started
    /install-atlas-cli
+   /atlas-cli-getting-started
    /connect-atlas-cli
    /atlas-cli-tutorials
    Atlas CLI Commands </command/atlas>


### PR DESCRIPTION
[Build Link](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6284ebad55f596c31df19efd)
[Jira Ticket Link](https://jira.mongodb.org/browse/DOCSP-22576)
[Staging 1](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22576-2/atlas-cli-getting-started/): Get Started with Atlas tutorial (within Atlas CLI docs. A different PR will edit Atlas docs)
[Staging 2](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22576-2/atlas-cli-tutorials/): New top-level page for tutorials
[Staging 3](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22576-2/connect-atlas-cli/): Connect from the Atlas CLI (small change)
[Staging 4](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22576-2/atlas-cli-quickstart/): Set up Atlas with atlas quickstart (small change)

This PR should be merged, backported to the stable branch (after release), and published before its counterpart in the Atlas docs.