### PR TITLE
Revert "(DOCSP-21720) Adds --skipConfig option to Connect page"

### DIFF
--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -113,17 +113,7 @@ from the {+atlas-cli+}.
 
       .. procedure::
 
-         .. step:: Run the authentication command with the ``--skipConfig`` flag.
-
-            Run the ``atlas auth login`` command in your terminal with the flag
-            to skip profile setup.
-
-            .. code-block:: sh
-
-               atlas auth login --skipConfig
-
-            The command opens a browser window and returns a one-time
-            activation code. This code expires after 10 minutes.
+         .. include:: /includes/steps-atlas-cli-auth-nonprog-default.rst
 
          .. step:: Sign into |service|.
 
@@ -141,6 +131,14 @@ from the {+atlas-cli+}.
             message:
 
             ``Successfully logged in as {Your Email Address}.``
+            
+            Accept the default profile configuration by pressing :guilabel:`Enter`
+            when the following options display:
+
+            - ``Default Org ID``
+            - ``Default Project ID``
+            - ``Default Output Format``
+            - ``Default MongoDB Shell Path``
 
             .. important:: 
 


### PR DESCRIPTION
Reverts mongodb/docs-atlas-cli#8 as --skipConfig was deprecated.

Build Link
Jira Ticket Link
Staging