### PR TITLE
(DOCSP-22658) Removes --skipConfig option from connection instructions

### DIFF
--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -113,17 +113,7 @@ from the {+atlas-cli+}.
 
       .. procedure::
 
-         .. step:: Run the authentication command with the ``--skipConfig`` flag.
-
-            Run the ``atlas auth login`` command in your terminal with the flag
-            to skip profile setup.
-
-            .. code-block:: sh
-
-               atlas auth login --skipConfig
-
-            The command opens a browser window and returns a one-time
-            activation code. This code expires after 10 minutes.
+         .. include:: /includes/steps-atlas-cli-auth-nonprog-default.rst
 
          .. step:: Sign into |service|.
 
@@ -141,6 +131,13 @@ from the {+atlas-cli+}.
             message:
 
             ``Successfully logged in as {Your Email Address}.``
+
+            Accept the default profile configuration by pressing :guilabel:`Enter` if the following options display:
+
+            - ``Default Org ID``
+            - ``Default Project ID``
+            - ``Default Output Format``
+            - ``Default MongoDB Shell Path``
 
             .. important:: 
 


### PR DESCRIPTION
[Build Link](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6286579d55f596c31d32708d)
Backports #29 