### PR TITLE
(DOCSP-22872): Fix brew upgrade typo

### DIFF
--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -390,7 +390,7 @@ method you used to install the {+atlas-cli+}:
             .. code-block:: sh
 
                brew update
-               brew upgrade mongocli-atlas-cli
+               brew upgrade mongodb-atlas-cli
 
          .. include:: /includes/steps-verify-update-atlas-cli.rst
 


### PR DESCRIPTION
[DOCSP-22872](https://jira.mongodb.org/browse/DOCSP-22872)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-22872-v2/install-atlas-cli/#follow-these-steps-1)
[Clean build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=628e831a7cf5397525cd0da3) (except for expected autocomplete command errors)