### PR TITLE
DOCSP-23105: remove RHEL 6 from atlas cli compat table

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -35,7 +35,7 @@ systems:
      - 2012, 2012R2, 2016, 2019
      - ``x86-64``
    * - Red Hat Enterprise Linux / CentOS
-     - 6, 7, 8
+     - 7, 8
      - ``x86-64``, ``ARM``
    * - SUSE Linux Enterprise Server
      - 12, 15


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-23105)
[Stage](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-23105/compatibility/)