### PR TITLE
(DOCSP-24624) Adds RHEL 9/Ubuntu 22.04 support, updates yum/apt to 6.0

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -43,7 +43,7 @@ mcli = "MongoDB CLI"
 mcli-long = "MongoDB Command Line Interface (``mongocli``)"
 mcli-version = "1.23.1"
 mdbagent = "MongoDB Agent"
-mdbVersion = "5.0"
+mdbVersion = "6.0"
 mongosh = ":binary:`~bin.mongosh`"
 
 [substitutions]

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -35,11 +35,11 @@ systems:
      - 2012, 2012R2, 2016, 2019
      - ``x86-64``
    * - Red Hat Enterprise Linux / CentOS
-     - 7, 8
+     - 7, 8, 9
      - ``x86-64``, ``ARM``
    * - SUSE Linux Enterprise Server
      - 12, 15
      - ``x86-64``, ``ARM``
    * - Ubuntu
-     - 18.04, 20.04
+     - 18.04, 20.04, 22.04
      - ``x86-64``, ``ARM``

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -95,9 +95,9 @@ Follow These Steps
                .. tab:: MongoDB Community Edition
                   :tabid: mdb-comm
 
-                  Create a ``/etc/yum.repos.d/mongodb-org-6.0.repo`` 
+                  Create a ``/etc/yum.repos.d/mongodb-org-{+mdbVersion+}.repo`` 
                   file so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace ``6.0`` with your
+                  ``yum``. Replace ``{+mdbVersion+}`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -108,12 +108,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-org-6.0]
+                           [mongodb-org-{+mdbVersion+}]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/6.0/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{+mdbVersion+}/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-{+mdbVersion+}.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -121,20 +121,20 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-org-6.0]
+                           [mongodb-org-{+mdbVersion+}]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/6.0/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/{+mdbVersion+}/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-{+mdbVersion+}.asc
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
                   Create a
-                  ``/etc/yum.repos.d/mongodb-enterprise-6.0.repo`` file
+                  ``/etc/yum.repos.d/mongodb-enterprise-{+mdbVersion+}.repo`` file
                   so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace ``6.0`` with your
+                  ``yum``. Replace ``{+mdbVersion+}`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -145,12 +145,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-enterprise-6.0]
+                           [mongodb-enterprise-{+mdbVersion+}]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/6.0/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/{+mdbVersion+}/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-{+mdbVersion+}.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -158,12 +158,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-enterprise-6.0]
+                           [mongodb-enterprise-{+mdbVersion+}]
                            name=MongoDB Enterprise Repository
-                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/6.0/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/{+mdbVersion+}/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-{+mdbVersion+}.asc
 
          .. step:: Install the {+atlas-cli+} and {+mongosh+}.
             
@@ -193,13 +193,13 @@ Follow These Steps
 
             From a terminal, issue the following command to import the MongoDB
             public GPG Key from
-            ``https://pgp.mongodb.com/server-6.0.asc``.
-            Replace ``6.0`` with your
+            ``https://pgp.mongodb.com/server-{+mdbVersion+}.asc``.
+            Replace ``{+mdbVersion+}`` with your
             edition of MongoDB. 
 
             .. code-block:: sh
      
-               wget -qO - https://pgp.mongodb.com/server-6.0.asc | sudo apt-key add -
+               wget -qO - https://pgp.mongodb.com/server-{+mdbVersion+}.asc | sudo apt-key add -
      
             A successful command returns an ``OK``.
 
@@ -210,91 +210,126 @@ Follow These Steps
                .. tab:: MongoDB Community Edition
                   :tabid: mdb-comm
 
-                  Create the list file
-                  ``/etc/apt/sources.list.d/mongodb-org-6.0.list`` for
-                  your version of Ubuntu. Replace ``6.0`` with your
-                  edition of MongoDB.
+                  Select Ubuntu or Debian, then select your version.
 
                   .. tabs::
 
-                     .. tab:: Ubuntu 22.04 (Jammy)
-                        :tabid: comm-jammy
+                     .. tab:: Ubuntu
+                        :tabid: ubuntu
 
-                        .. code-block:: sh
+                        Create the list file 
+                        ``/etc/apt/sources.list.d/mongodb-org-
+                        {+mdbVersion+}.list`` for your version of
+                        Ubuntu. Replace ``{+mdbVersion+}`` with your
+                        edition of MongoDB.
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                        .. tabs::
 
-                     .. tab:: Ubuntu 20.04 (Focal)
-                        :tabid: comm-focal
+                           .. tab:: Ubuntu 22.04 (Jammy)
+                              :tabid: comm-jammy
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
-                     .. tab:: Ubuntu 18.04 (Bionic)
-                        :tabid: comm-bionic
+                           .. tab:: Ubuntu 20.04 (Focal)
+                              :tabid: comm-focal
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
-                     .. tab:: Debian 10 (Buster)
-                        :tabid: comm-deb-10
+                           .. tab:: Ubuntu 18.04 (Bionic)
+                              :tabid: comm-bionic
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
-                     .. tab:: Debian 9 (Stretch)
-                        :tabid: comm-deb-9
+                     .. tab:: Debian
+                        :tabid: debian
 
-                        .. code-block:: sh
+                        Create the list file 
+                        ``/etc/apt/sources.list.d/mongodb-org-
+                        {+mdbVersion+}.list`` for your version of
+                        Debian. Replace ``{+mdbVersion+}`` with your
+                        edition of MongoDB.
 
-                           echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+                        .. tabs::
+
+                           .. tab:: Debian 10 (Buster)
+                              :tabid: comm-deb-10
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+
+                           .. tab:: Debian 9 (Stretch)
+                              :tabid: comm-deb-9
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
-                  Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list``
-                  file for MongoDB. Replace ``6.0`` with your
-                  edition of MongoDB.
+                  Select Ubuntu or Debian, then select your version.
         
                   .. tabs::
 
-                     .. tab:: Ubuntu 22.04 (Jammy)
-                        :tabid: ent-jammy
+                     .. tab:: Ubuntu
+                        :tabid: ubuntu
 
-                        .. code-block:: sh
+                        Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list`` file for your version of Ubuntu.
+                        Replace ``{+mdbVersion+}`` with your edition of
+                        MongoDB.
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                        .. tabs::
 
-                     .. tab:: Ubuntu 20.04 (Focal)
-                        :tabid: ent-focal
+                           .. tab:: Ubuntu 22.04 (Jammy)
+                              :tabid: ent-jammy
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
-                     .. tab:: Ubuntu 18.04 (Bionic)
-                        :tabid: ent-bionic
+                           .. tab:: Ubuntu 20.04 (Focal)
+                              :tabid: ent-focal
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
-                     .. tab:: Debian 10 (Buster)
-                        :tabid: ent-deb-10
+                           .. tab:: Ubuntu 18.04 (Bionic)
+                              :tabid: ent-bionic
 
-                        .. code-block:: sh
+                              .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
-                     .. tab:: Debian 9 (Stretch)
-                        :tabid: ent-deb-9
+                     .. tab:: Debian
+                        :tabid: debian
 
-                        .. code-block:: sh
+                        Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list`` file for your version of Debian.
+                        Replace ``{+mdbVersion+}`` with your edition of
+                        MongoDB.
 
-                           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                        .. tabs::
+
+                           .. tab:: Debian 10 (Buster)
+                              :tabid: ent-deb-10
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
+                           .. tab:: Debian 9 (Stretch)
+                              :tabid: ent-deb-9
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
          .. step:: Refresh the package database.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -218,8 +218,8 @@ Follow These Steps
                         :tabid: ubuntu
 
                         Create the list file 
-                        ``/etc/apt/sources.list.d/mongodb-org-
-                        {+mdbVersion+}.list`` for your version of
+                        ``/etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list`` 
+                        for your version of
                         Ubuntu. Replace ``{+mdbVersion+}`` with your
                         edition of MongoDB.
 
@@ -250,8 +250,8 @@ Follow These Steps
                         :tabid: debian
 
                         Create the list file 
-                        ``/etc/apt/sources.list.d/mongodb-org-
-                        {+mdbVersion+}.list`` for your version of
+                        ``/etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list`` 
+                        for your version of
                         Debian. Replace ``{+mdbVersion+}`` with your
                         edition of MongoDB.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -95,9 +95,9 @@ Follow These Steps
                .. tab:: MongoDB Community Edition
                   :tabid: mdb-comm
 
-                  Create a ``/etc/yum.repos.d/mongodb-org-5.0.repo`` 
+                  Create a ``/etc/yum.repos.d/mongodb-org-6.0.repo`` 
                   file so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace ``5.0`` with your
+                  ``yum``. Replace ``6.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -108,12 +108,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-org-5.0]
+                           [mongodb-org-6.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/5.0/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/6.0/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -121,20 +121,20 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-org-5.0]
+                           [mongodb-org-6.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/x86_64/
+                           baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/6.0/x86_64/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
                   Create a
-                  ``/etc/yum.repos.d/mongodb-enterprise-5.0.repo`` file
+                  ``/etc/yum.repos.d/mongodb-enterprise-6.0.repo`` file
                   so that you can install {+atlas-cli+} directly using
-                  ``yum``. Replace ``5.0`` with your
+                  ``yum``. Replace ``6.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
@@ -145,12 +145,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
           
-                           [mongodb-enterprise-5.0]
+                           [mongodb-enterprise-6.0]
                            name=MongoDB Repository
-                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/5.0/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/6.0/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
 
                      .. tab:: Amazon Linux
                         :tabid: amazon
@@ -158,12 +158,12 @@ Follow These Steps
                         .. code-block:: text
                            :emphasize-lines: 1
 
-                           [mongodb-enterprise-5.0]
+                           [mongodb-enterprise-6.0]
                            name=MongoDB Enterprise Repository
-                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/5.0/$basearch/
+                           baseurl=https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/6.0/$basearch/
                            gpgcheck=1
                            enabled=1
-                           gpgkey=https://pgp.mongodb.com/server-5.0.asc
+                           gpgkey=https://pgp.mongodb.com/server-6.0.asc
 
          .. step:: Install the {+atlas-cli+} and {+mongosh+}.
             
@@ -193,13 +193,13 @@ Follow These Steps
 
             From a terminal, issue the following command to import the MongoDB
             public GPG Key from
-            ``https://pgp.mongodb.com/server-5.0.asc``.
-            Replace ``5.0`` with your
+            ``https://pgp.mongodb.com/server-6.0.asc``.
+            Replace ``6.0`` with your
             edition of MongoDB. 
 
             .. code-block:: sh
      
-               wget -qO - https://pgp.mongodb.com/server-5.0.asc | sudo apt-key add -
+               wget -qO - https://pgp.mongodb.com/server-6.0.asc | sudo apt-key add -
      
             A successful command returns an ``OK``.
 
@@ -211,76 +211,90 @@ Follow These Steps
                   :tabid: mdb-comm
 
                   Create the list file
-                  ``/etc/apt/sources.list.d/mongodb-org-5.0.list`` for
-                  your version of Ubuntu. Replace ``5.0`` with your
+                  ``/etc/apt/sources.list.d/mongodb-org-6.0.list`` for
+                  your version of Ubuntu. Replace ``6.0`` with your
                   edition of MongoDB.
 
                   .. tabs::
+
+                     .. tab:: Ubuntu 22.04 (Jammy)
+                        :tabid: comm-jammy
+
+                        .. code-block:: sh
+
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
                      .. tab:: Ubuntu 20.04 (Focal)
                         :tabid: comm-focal
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
                      .. tab:: Ubuntu 18.04 (Bionic)
                         :tabid: comm-bionic
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
                      .. tab:: Debian 10 (Buster)
                         :tabid: comm-deb-10
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+                           echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
                      .. tab:: Debian 9 (Stretch)
                         :tabid: comm-deb-9
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+                           echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
 
                   Create a ``/etc/apt/sources.list.d/mongodb-enterprise.list``
-                  file for MongoDB. Replace ``5.0`` with your
+                  file for MongoDB. Replace ``6.0`` with your
                   edition of MongoDB.
         
                   .. tabs::
+
+                     .. tab:: Ubuntu 22.04 (Jammy)
+                        :tabid: ent-jammy
+
+                        .. code-block:: sh
+
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Ubuntu 20.04 (Focal)
                         :tabid: ent-focal
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Ubuntu 18.04 (Bionic)
                         :tabid: ent-bionic
 
                         .. code-block:: sh
 
-                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian 10 (Buster)
                         :tabid: ent-deb-10
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian 9 (Stretch)
                         :tabid: ent-deb-9
 
                         .. code-block:: sh
 
-                           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/5.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                           echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/6.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
          .. step:: Refresh the package database.
 


### PR DESCRIPTION
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62fd0970b354ebcf05237a17)
[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-24624)
[Staging 1](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-24110/install-atlas-cli/) (yum/apt tabs)
[Staging 2](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-24110/compatibility/)