### PR TITLE
DOCSP-24941 Add support for Chocholatey to the installation options

### DIFF
--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -52,6 +52,20 @@ To check whether your operating system is compatible with the
          
          sudo apt-get install gnupg
 
+   .. tab:: Chocolatey
+      :tabid: chocolatey
+
+      Complete the Prerequisites
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      To install the {+atlas-cli+} using Chocolatey, you must do the 
+      following:
+
+      1. Ensure that your system meets the `requirements 
+         <https://docs.chocolatey.org/en-us/choco/setup#requirements>`__ for installing Chocolatey.
+      #. Install Chocolatey using ``cmd.exe`` or ``PowerShell.exe``. To 
+         learn more, see `Installing Chocolatey <https://docs.chocolatey.org/en-us/choco/setup#installing-chocolatey>`__.
+
    .. tab:: Download Binary
       :tabid: download-binary
 
@@ -358,6 +372,23 @@ Follow These Steps
 
          .. include:: /includes/steps-verify-atlas-cli.rst
 
+   .. tab:: Chocolatey
+      :tabid: chocolatey
+
+      .. procedure::
+
+         .. step:: Install the {+atlas-cli+}.
+
+            .. code-block:: shell 
+
+               choco install mongodb-atlas
+
+         .. step:: When prompted, enter ``A`` to confirm installation.
+
+         .. step:: Close and reopen your terminal after the installation to see the changes in your path.
+
+         .. include:: /includes/steps-verify-atlas-cli.rst
+
    .. tab:: Download Binary
       :tabid: download-binary
 
@@ -492,6 +523,22 @@ method you used to install the {+atlas-cli+}:
             .. code-block:: sh
 
                sudo apt-get install --only-upgrade mongodb-atlas-cli
+
+         .. include:: /includes/steps-verify-update-atlas-cli.rst
+
+   .. tab:: Chocolatey
+      :tabid: chocolatey
+
+      Follow These Steps
+      ~~~~~~~~~~~~~~~~~~
+
+      .. procedure::
+
+         .. step:: Install the {+atlas-cli+}.
+
+            .. code-block:: shell 
+
+               choco upgrade mongodb-atlas
 
          .. include:: /includes/steps-verify-update-atlas-cli.rst
 


### PR DESCRIPTION
- [DOCSP-24941](https://jira.mongodb.org/browse/DOCSP-24941)
- [Stage](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-24941/install-atlas-cli/)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=632209e89ef0f101154e08b7) (has errors unrelated to changes in this PR)