### PR TITLE
(DOCSP-25383): Add Debian 11 and remove Debian 9 compatibility - Atlas CLI

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -23,7 +23,7 @@ systems:
      - 2
      - ``x86-64``, ``ARM``
    * - Debian
-     - 9, 10
+     - 10, 11
      - ``x86-64``, ``ARM``
    * - MacOS
      - 10.0 and later


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-25343)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=632a271e9ef0f10115741c46)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-25383/compatibility/)