### PR TITLE
DOCSP-25235 Add section on how to specifying a config file path

### DIFF
--- a/source/atlas-cli-save-connection-settings.txt
+++ b/source/atlas-cli-save-connection-settings.txt
@@ -58,15 +58,22 @@ location depending on your operating system:
 
          $XDG_CONFIG_HOME/atlascli
 
+      By default, {+atlas-cli+} saves the configuration file in the 
+      path defined in the ``$XDG_CONFIG_HOME`` environment variable. 
+      You can modify the path defined in the ``$XDG_CONFIG_HOME`` 
+      variable to your preferred location. To learn more about 
+      modifying the ``$XDG_CONFIG_HOME`` variable, see `XDG Base 
+      Directory Specification <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
+      
       If ``$XDG_CONFIG_HOME`` is not set, the {+atlas-cli+} uses:
 
       .. code-block::
 
          $HOME/.config/atlascli
 
-The
-{+atlas-cli+} grants the user who ran the command read and write access to
-the file. 
+
+The {+atlas-cli+} grants the user who ran the command read and write 
+access to the file. 
 
 .. _atlas-cli-set-profile:
 


### PR DESCRIPTION
- [DOCSP-25235](https://jira.mongodb.org/browse/DOCSP-25235)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=632b6aa49ef0f10115a340b8)
- [Stage](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-25235/atlas-cli-save-connection-settings/) - see changes under Linux tab