### PR TITLE
(DOCSP-25907) Fix the Debian tabs

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -63,10 +63,10 @@ Get started quickly with two commands:
             #. Adds your IP address to your project's IP access list.
             #. Creates a MongoDB user for your |service| 
                {+database-deployment+}.
-            #. Connect to your new {+database-deployment+} using the
+            #. Connects to your new {+database-deployment+} using the
                MongoDB Shell, {+mongosh+}.
 
-            To learn more, see the :doc:`atlas setup documentation </command/atlas-setup>`.
+            To learn more, see the :ref:`atlas-setup` command.
 
       .. image:: /images/setup.gif
          :alt: atlas setup command

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -16,8 +16,8 @@ Install the {+atlas-cli+} to quickly provision and manage |service|
 Install the {+atlas-cli+}
 -------------------------
 
-Select an installation method below and follow the steps to install the
-{+atlas-cli+}.
+Select one of the following installation methods and follow the steps to
+install the {+atlas-cli+}.
 
 To check whether your operating system is compatible with the 
 {+atlas-cli+}, see :ref:`compatibility-atlas-cli`.
@@ -271,19 +271,19 @@ Follow These Steps
 
                         .. tabs::
 
-                           .. tab:: Debian 10 (Buster)
+                           .. tab:: Debian 11 (bullseye)
+                              :tabid: comm-deb-11
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+
+                           .. tab:: Debian 10 (buster)
                               :tabid: comm-deb-10
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
-
-                           .. tab:: Debian 9 (Stretch)
-                              :tabid: comm-deb-9
-
-                              .. code-block:: sh
-
-                                 echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb http://repo.mongodb.org/apt/debian/dists/buster/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent
@@ -331,19 +331,19 @@ Follow These Steps
 
                         .. tabs::
 
-                           .. tab:: Debian 10 (Buster)
+                           .. tab:: Debian 11 (bullseye)
+                              :tabid: ent-deb-11
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.com/apt/dists/debian/bullseye/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
+                           .. tab:: Debian 10 (bullseye)
                               :tabid: ent-deb-10
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
-
-                           .. tab:: Debian 9 (Stretch)
-                              :tabid: ent-deb-9
-
-                              .. code-block:: sh
-
-                                 echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb http://repo.mongodb.com/apt/dists/debian/buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
          .. step:: Refresh the package database.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -244,21 +244,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: comm-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: comm-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                      .. tab:: Debian
                         :tabid: debian
@@ -271,14 +271,14 @@ Follow These Steps
 
                         .. tabs::
 
-                           .. tab:: Debian 11 (bullseye)
+                           .. tab:: Debian 11 (Bullseye)
                               :tabid: comm-deb-11
 
                               .. code-block:: sh
 
                                  echo "deb http://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
-                           .. tab:: Debian 10 (buster)
+                           .. tab:: Debian 10 (Buster)
                               :tabid: comm-deb-10
 
                               .. code-block:: sh
@@ -306,21 +306,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: ent-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: ent-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian
                         :tabid: debian
@@ -331,19 +331,19 @@ Follow These Steps
 
                         .. tabs::
 
-                           .. tab:: Debian 11 (bullseye)
+                           .. tab:: Debian 11 (Bullseye)
                               :tabid: ent-deb-11
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.com/apt/dists/debian/bullseye/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb http://repo.mongodb.com/apt/dists/debian/dists/bullseye/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
-                           .. tab:: Debian 10 (bullseye)
+                           .. tab:: Debian 10 (Buster)
                               :tabid: ent-deb-10
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.com/apt/dists/debian/buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb http://repo.mongodb.com/apt/debian/dists/buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
          .. step:: Refresh the package database.
 


### PR DESCRIPTION
[DOCSP-25907](https://jira.mongodb.org/browse/DOCSP-25907)

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-25907/install-atlas-cli/) -- please find Debian tabs in the install and review those sections on this page.

Questions to reviewers:
When making updates, I noticed that the path to Debian ant is as follows:
`http://repo.mongodb.com/apt/debian/dists/bullseye/mongodb-enterprise/6.0/`
However, the paths in the docs are written without the /dists directory, and with /debian bullseye notation. I changed that but want to verify that this change is correct. It might be that there is some redirect in place that I am not observing.
If, however, this change is accurate, then this would apply to ubuntu paths as well. Please confirm or deny my findings!

In addition to this change, I noticed a few small items on the landing page and made those changes. Thank you for your reviews. @gssbzn and @sarahsimpers 

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63509f027f102f5cea0a6412) is clean.