### PR TITLE
Backport of DOCSP-25907 to Atlas CLI v1.2: Debian tabs and paths for Debian 10 and 11

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -63,10 +63,10 @@ Get started quickly with two commands:
             #. Adds your IP address to your project's IP access list.
             #. Creates a MongoDB user for your |service| 
                {+database-deployment+}.
-            #. Connect to your new {+database-deployment+} using the
+            #. Connects to your new {+database-deployment+} using the
                MongoDB Shell, {+mongosh+}.
 
-            To learn more, see the :doc:`atlas setup documentation </command/atlas-setup>`.
+            To learn more, see the :ref:`atlas setup <atlas-setup>` command.
 
       .. image:: /images/setup.gif
          :alt: atlas setup command

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -244,21 +244,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: comm-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: comm-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                      .. tab:: Debian
                         :tabid: debian
@@ -270,6 +270,13 @@ Follow These Steps
                         edition of MongoDB.
 
                         .. tabs::
+
+                           .. tab:: Debian 11 (Bullseye)
+                              :tabid: comm-deb-11
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.org/apt/debian/dists/bullseye/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Debian 10 (Buster)
                               :tabid: comm-deb-10
@@ -306,21 +313,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: ent-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: ent-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu/dists/bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian
                         :tabid: debian
@@ -331,19 +338,19 @@ Follow These Steps
 
                         .. tabs::
 
+                           .. tab:: Debian 11 (Bullseye)
+                              :tabid: ent-deb-11
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.com/apt/dists/debian/dists/bullseye/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+
                            .. tab:: Debian 10 (Buster)
                               :tabid: ent-deb-10
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.com/apt/debian buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
-
-                           .. tab:: Debian 9 (Stretch)
-                              :tabid: ent-deb-9
-
-                              .. code-block:: sh
-
-                                 echo "deb http://repo.mongodb.com/apt/debian stretch/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb http://repo.mongodb.com/apt/debian/dists/buster/mongodb-enterprise/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
          .. step:: Refresh the package database.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -283,14 +283,8 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb http://repo.mongodb.org/apt/debian/dists/buster/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
-                           .. tab:: Debian 9 (Stretch)
-                              :tabid: comm-deb-9
-
-                              .. code-block:: sh
-
-                                 echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                .. tab:: MongoDB Enterprise Edition
                   :tabid: mdb-ent


### PR DESCRIPTION
Backport of #72 

Staging

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=635194a77f102f5cea399169) is clean.