### PR TITLE
(DOCSP-26171) Adds example for geosharded cluster.

### DIFF
--- a/source/cluster-config-file.txt
+++ b/source/cluster-config-file.txt
@@ -168,7 +168,7 @@ following example file:
 
 .. _multi-cloud-example-cluster-config-file:
 
-Multi-Cloud Example Cluster Configuration File
+Example Multi-Cloud Cluster Configuration File
 ----------------------------------------------
 
 To create a multi-cloud {+cluster+}, specify more than one
@@ -176,3 +176,10 @@ service provider for your ``regionConfigs`` objects as shown in the
 following example file:
 
 .. literalinclude:: /includes/json-cluster-config-file-multi.json
+
+Example Geosharded Cluster Configuration File
+---------------------------------------------
+
+To create a :ref:`geosharded <global-clusters>` {+cluster+}, specify zones for your ``replicationSpecs`` objects as shown in the following example file:
+
+.. literalinclude:: /includes/geosharded-cluster-config-file.json

--- a/source/cluster-config-file.txt
+++ b/source/cluster-config-file.txt
@@ -150,7 +150,7 @@ Optional and Conditional {+Cluster+} Settings
 ---------------------------------------------
 
 Your {+cluster+} configuration file may contain additional optional or
-conditional {+cluster+} settings. If you selected a ``clusterType`` of ``GEOSHARDED``, you must specify these {+cluster+} settings either
+conditional {+cluster+} settings. If you selected a ``clusterType`` of ``GEOSHARDED``, you must specify the following {+cluster+} settings either
 in the configuration file or as flags in the command:
 
 .. list-table:: 
@@ -174,7 +174,7 @@ in the configuration file or as flags in the command:
 
        If you specify a ``numShards`` value of ``1`` and a
        ``clusterType`` of ``SHARDED``, |service| deploys a single-shard
-       `sharded cluster <https://www.mongodb.com/docs/manual/reference/glossary/#std-term-sharded-cluster>`__.
+       :manual:`sharded cluster </reference/glossary/#std-term-sharded-cluster>`.
 
        Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
 

--- a/source/cluster-config-file.txt
+++ b/source/cluster-config-file.txt
@@ -150,10 +150,45 @@ Optional and Conditional {+Cluster+} Settings
 ---------------------------------------------
 
 Your {+cluster+} configuration file may contain additional optional or
-conditional {+cluster+} settings. For a full list of available
+conditional {+cluster+} settings. If you selected a ``clusterType`` of ``GEOSHARDED``, you must specify these {+cluster+} settings either
+in the configuration file or as flags in the command:
+
+.. list-table:: 
+   :header-rows: 1 
+   :widths: 20 10 70 
+
+   * - Field 
+     - Type 
+     - Description 
+
+   * - ``replicationSpecs.``
+       ``numShards``
+     - string
+     - Positive integer that specifies the number of shards to deploy
+       in each specified zone. Provide this value if you set a
+       ``clusterType`` of ``SHARDED`` or ``GEOSHARDED``. Omit this
+       value if you selected a ``clusterType`` of ``REPLICASET``.
+
+       This API resource accepts ``1`` through ``50``, inclusive. This
+       parameter defaults to ``1``.
+
+       If you specify a ``numShards`` value of ``1`` and a
+       ``clusterType`` of ``SHARDED``, |service| deploys a single-shard
+       `sharded cluster <https://www.mongodb.com/docs/manual/reference/glossary/#std-term-sharded-cluster>`__.
+
+       Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
+
+   * - ``replicationSpecs.``
+       ``zoneName``
+     - string
+     - Name for the zone in a :ref:`Global Cluster <global-clusters>`. 
+       Provide this value if you set ``clusterType`` to ``GEOSHARDED``.
+
+For a full list of available
 settings, see the API documentation for 
-:atlas:`Create One Multi-Cloud Cluster from One Project 
-</reference/api-resources-spec/#operation/createOneAdvancedClusterFromOneProject>`.
+:oas-atlas-op:`Create One Cluster </createOneCluster>` and 
+:oas-atlas-op:`Create One Multi-Cloud Cluster from One Project 
+</createCluster>`.
 
 .. _example-cluster-config-file:
 

--- a/source/includes/geosharded-cluster-config-file.json
+++ b/source/includes/geosharded-cluster-config-file.json
@@ -1,0 +1,93 @@
+{
+    "backupEnabled": false,
+    "biConnector": {
+      "enabled": false,
+      "readPreference": "secondary"
+    },
+    "clusterType": "GEOSHARDED",
+    "diskSizeGB": 100,
+    "encryptionAtRestProvider": "NONE",
+    "mongoDBMajorVersion": "5.0",
+    "name": "myCluster",
+    "paused": false,
+    "pitEnabled": false,
+    "stateName": "IDLE",
+    "replicationSpecs": [
+      {
+        "numShards": 1,
+        "zoneName": "US-1",
+        "regionConfigs": [
+          {
+            "analyticsSpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "electableSpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 3
+            },
+            "readOnlySpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "autoScaling": {
+              "diskGB": {
+                "enabled": true
+              },
+              "compute": {
+                "enabled": false,
+                "scaleDownEnabled": false
+              }
+            },
+            "priority": 7,
+            "providerName": "AWS",
+            "regionName": "US_EAST_1"
+          }
+        ]
+      },
+      {
+        "numShards": 1,
+        "zoneName": "US-2",
+        "regionConfigs": [
+          {
+            "analyticsSpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "electableSpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 3
+            },
+            "readOnlySpecs": {
+              "diskIOPS": 3000,
+              "ebsVolumeType": "STANDARD",
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "autoScaling": {
+              "diskGB": {
+                "enabled": true
+              },
+              "compute": {
+                "enabled": false,
+                "scaleDownEnabled": false
+              }
+            },
+            "priority": 7,
+            "providerName": "AWS",
+            "regionName": "US_EAST_2"
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
I tested the example config in Cloud Dev and it created a geosharded cluster with no issues.

[Jira](https://jira.mongodb.org/browse/DOCSP-26171)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63b457a9dc742b91f27324cc) (includes [known errors](https://mongodb.slack.com/archives/CGX40QH7Z/p1646141185642329))
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-26171/cluster-config-file/#example-geosharded-cluster-configuration-file)