### PR TITLE
(DOCSP-26322) Added an IP access list restriction

### DIFF
--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -96,6 +96,16 @@ Complete the Prerequisites
 
       - :ref:`Install the {+atlas-cli+} <install-atlas-cli>`.
       - Add your host's IP address to the :ref:`IP access list <access-list>`.
+  
+        If you log into the {+atlas-cli+} with your Atlas user credentials,
+        and your organization's owners enable
+        :atlas:`IP access list for the Atlas UI for an organization
+        </tutorial/manage-organizations/#require-ip-access-list-for-the-atlas-ui>`,
+        then to run any commands in this organization, your IP address must
+        be included in the IP access list or CIDR ranges defined in that list.
+        To learn more, see :atlas:`Require IP Access List for the Atlas UI
+        </tutorial/manage-organizations/#require-ip-access-list-for-the-atlas-ui>`.
+
 
    .. tab:: Programmatic Use
       :tabid: atlas-config-init

--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -97,13 +97,11 @@ Complete the Prerequisites
       - :ref:`Install the {+atlas-cli+} <install-atlas-cli>`.
       - Add your host's IP address to the :ref:`IP access list <access-list>`.
   
-        If you log into the {+atlas-cli+} with your Atlas user credentials,
-        and your organization's owners enable
-        :atlas:`IP access list for the Atlas UI for an organization
+        If you authenticate with your |service| user credentials
+        and your organization's owners enable :atlas:`IP access list for the Atlas UI for an organization
         </tutorial/manage-organizations/#require-ip-access-list-for-the-atlas-ui>`,
-        then to run any commands in this organization, your IP address must
-        be included in the IP access list or CIDR ranges defined in that list.
-        To learn more, see :atlas:`Require IP Access List for the Atlas UI
+        your IP address must be added to the IP access list to run commands
+        in this organization. To learn more, see :atlas:`Require IP Access List for the Atlas UI
         </tutorial/manage-organizations/#require-ip-access-list-for-the-atlas-ui>`.
 
 


### PR DESCRIPTION
[DOCSP-26322](https://jira.mongodb.org/browse/DOCSP-26322)

@jiayong0 and @tsck, could you please review?

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-26322/connect-atlas-cli/#connect-with-minimum-required-settings) (choose the "non-programmatic" tab)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63f4ebd105dd3cc814caf887)

@sarahsimpers, this must be merged and published only after this feature branch for Atlas gets merged and published ([ip-access-list-full](https://github.com/10gen/cloud-docs/tree/ip-access-list-full)). 