### PR TITLE
(DOCSP-29111): Add info on how to use the Open API spec to create JSON config files

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -18,6 +18,7 @@ toc_landing_pages = [
   "/connect-atlas-cli",
   "/install-atlas-cli",
   "/migrate-to-atlas-cli",
+  "/reference/json",
   "/telemetry"
   ]
 

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -1,8 +1,8 @@
 .. _json-cluster-config:
 
-==================
-JSON Configuration
-==================
+======
+|json| 
+======
 
 .. contents:: On this page
    :local:
@@ -23,12 +23,13 @@ Usage
 -----
 
 To learn which settings are accepted by the {+atlas-cli+}, view the request 
-body schema and request samples in the :ref:`Atlas Admin API Specification <api-resources-spec>` 
-for the endpoint that corresponds to the {+atlas-cli+} command:
+body schema and request samples in the :ref:`Atlas Admin API Specification 
+<api-resources-spec>` for the endpoint that corresponds to the {+atlas-cli+} 
+command:
 
 .. list-table::
   :header-rows: 1
-  :widths: 60 40
+  :widths: 50 50
           
   * - {+atlas-cli+} Command
     - API Endpoint
@@ -37,13 +38,13 @@ for the endpoint that corresponds to the {+atlas-cli+} command:
     - :oas-atlas-op:`Create One Cluster </createLegacyCluster>`
 
   * - :ref:`atlas-clusters-update`
-    - :oas-atlas-op:`Update Configuration of One Cluster </updateClusterConfiguration>`.
+    - :oas-atlas-op:`Update Configuration of One Cluster </updateClusterConfiguration>`
 
   * - :ref:`atlas-clusters-upgrade`
     - :oas-atlas-op:`Upgrade One Shared-tier Cluster </upgradeSharedCluster>`
 
   * - :ref:`atlas-backups-schedule-update`
-    - :oas-atlas-op:`Update Cloud Backup Schedule for One Cluster </updateBackupSchedule>`.
+    - :oas-atlas-op:`Update Cloud Backup Schedule for One Cluster </updateBackupSchedule>`
 
   * - :ref:`atlas-clusters-search-indexes-create`
     - :oas-atlas-op:`Create One Atlas Search Index </createAtlasSearchIndex>`
@@ -51,15 +52,19 @@ for the endpoint that corresponds to the {+atlas-cli+} command:
   * - :ref:`atlas-clusters-search-indexes-update`
     - :oas-atlas-op:`Update One Atlas Search Index </updateAtlasSearchIndex>`
 
-Then, when running the command, specify the ``--file`` option and provide the 
-JSON configuration file that defines your desired settings. 
+When you run the command in your terminal, specify the ``--file`` option 
+and provide the path to the |json| configuration file that defines your 
+desired settings. 
 
-For example, the following command enables backups and adds a label
-to the ``myCluster`` deployment:
+Example
+~~~~~~~
+
+For example, consider the following configuration file
+to enable backups and add a label:
 
 .. code-block:: sh
+   :caption: /example.json
 
-   atlas clusters update myCluster --file 
    {
      "backupEnabled" : true,
      "labels": [
@@ -67,8 +72,16 @@ to the ``myCluster`` deployment:
          "key": "foo",
          "value": "bar"
        }
-     ],
+     ]
    } 
+
+The following command updates the ``myCluster`` deployment
+based on the settings specified in the ``/example.json`` 
+configuration file:
+
+.. code-block:: sh
+
+   atlas clusters create myCluster --file /example.json
 
 {+Cluster+} Configuration File
 ------------------------------

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -1,7 +1,93 @@
+.. _json-cluster-config:
 
-======
-|json|
-======
+==================
+JSON Configuration
+==================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+The {+atlas-cli+} accepts ``.json`` configuration files. You can use a 
+configuration file to specify settings when using the {+atlas-cli+} to:
+
+- :ref:`Create <atlas-clusters-create>`, :ref:`update <atlas-clusters-update>`, 
+  or :ref:`upgrade a cluster <atlas-clusters-upgrade>`.
+- :ref:`Update a cloud backup schedule <atlas-backups-schedule-update>`.
+- :ref:`Create <atlas-clusters-search-indexes-create>` or 
+  :ref:`update an Atlas Search Index <atlas-clusters-search-indexes-update>`.
+
+Usage
+-----
+
+To learn which settings are accepted by the {+atlas-cli+}, view the request 
+body schema and request samples in the :ref:`Atlas Admin API Specification <api-resources-spec>` 
+for the endpoint that corresponds to the {+atlas-cli+} command:
+
+.. list-table::
+  :header-rows: 1
+  :widths: 60 40
+          
+  * - {+atlas-cli+} Command
+    - API Endpoint
+
+  * - :ref:`atlas-clusters-create`
+    - :oas-atlas-op:`Create One Cluster </createLegacyCluster>`
+
+  * - :ref:`atlas-clusters-update`
+    - :oas-atlas-op:`Update Configuration of One Cluster </updateClusterConfiguration>`.
+
+  * - :ref:`atlas-clusters-upgrade`
+    - :oas-atlas-op:`Upgrade One Shared-tier Cluster </upgradeSharedCluster>`
+
+  * - :ref:`atlas-backups-schedule-update`
+    - :oas-atlas-op:`Update Cloud Backup Schedule for One Cluster </updateBackupSchedule>`.
+
+  * - :ref:`atlas-clusters-search-indexes-create`
+    - :oas-atlas-op:`Create One Atlas Search Index </createAtlasSearchIndex>`
+
+  * - :ref:`atlas-clusters-search-indexes-update`
+    - :oas-atlas-op:`Update One Atlas Search Index </updateAtlasSearchIndex>`
+
+Then, when running the command, specify the ``--file`` option and provide the 
+JSON configuration file that defines your desired settings. 
+
+For example, the following command enables backups and adds a label
+to the ``myCluster`` deployment:
+
+.. code-block:: sh
+
+   atlas clusters update myCluster --file 
+   {
+     "backupEnabled" : true,
+     "labels": [
+       {
+         "key": "foo",
+         "value": "bar"
+       }
+     ],
+   } 
+
+{+Cluster+} Configuration File
+------------------------------
+
+To learn more about {+cluster+} configuration files, see 
+:ref:`atlas-cli-cluster-config-file`. For sample files,
+see:
+
+- :ref:`example-cluster-config-file`
+- :ref:`multi-cloud-example-cluster-config-file`
+- :ref:`geosharded-example-cluster-config-file`
+
+
+Cloud Backup Schedule Configuration File
+----------------------------------------
+
+To learn more about cloud backup schedule configuration files, see 
+:ref:`atlas-cli-cloud-backup-schedule-config-file`. For a sample file,
+see :ref:`example-cloud-backup-schedule-config-file`.
 
 .. toctree::
    :titlesonly:

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -23,7 +23,7 @@ Usage
 -----
 
 To learn which settings are accepted by the {+atlas-cli+}, view the request 
-body schema and request samples in the :ref:`Atlas Admin API Specification 
+body schema and copy the request samples in the :ref:`Atlas Admin API Specification 
 <api-resources-spec>` for the endpoint that corresponds to the {+atlas-cli+} 
 command:
 
@@ -69,8 +69,8 @@ to enable backups and add a label:
      "backupEnabled" : true,
      "labels": [
        {
-         "key": "foo",
-         "value": "bar"
+         "key": "<myKey>",
+         "value": "<myValue>"
        }
      ]
    } 

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -1,7 +1,7 @@
 .. _json-cluster-config:
 
 ======
-|json| 
+|json|
 ======
 
 .. contents:: On this page
@@ -76,12 +76,11 @@ to enable backups and add a label:
    } 
 
 The following command updates the ``myCluster`` deployment
-based on the settings specified in the ``/example.json`` 
-configuration file:
+based on the settings specified in the configuration file:
 
 .. code-block:: sh
 
-   atlas clusters create myCluster --file /example.json
+   atlas clusters update myCluster --file /example.json
 
 {+Cluster+} Configuration File
 ------------------------------

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -10,8 +10,9 @@
    :depth: 1
    :class: singlecol
 
-The {+atlas-cli+} accepts ``.json`` configuration files. You can use a 
-configuration file to specify settings when using the {+atlas-cli+} to:
+If an {+atlas-cli+} command accepts the ``--file`` option, you can pass 
+a ``.json`` configuration file to define specific settings. For example, 
+you can pass a configuration file when using the {+atlas-cli+} to:
 
 - :ref:`Create <atlas-clusters-create>`, :ref:`update <atlas-clusters-update>`, 
   or :ref:`upgrade a cluster <atlas-clusters-upgrade>`.
@@ -25,7 +26,7 @@ Usage
 To learn which settings are accepted by the {+atlas-cli+}, view the request 
 body schema and copy the request samples in the :ref:`Atlas Admin API Specification 
 <api-resources-spec>` for the endpoint that corresponds to the {+atlas-cli+} 
-command:
+command. The commands you can use include but are not limited to:
 
 .. list-table::
   :header-rows: 1

--- a/source/reference/json/cluster-config-file.txt
+++ b/source/reference/json/cluster-config-file.txt
@@ -210,6 +210,8 @@ following example file:
 
 .. literalinclude:: /includes/json-cluster-config-file-multi.json
 
+.. _geosharded-example-cluster-config-file:
+
 Example Geosharded Cluster Configuration File
 ---------------------------------------------
 


### PR DESCRIPTION
Adds info to JSON page about using the Open API spec to create JSON configuration files.

[Jira](https://jira.mongodb.org/browse/DOCSP-29111)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-29111/reference/json/)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=644c32b27efd2382b35f5c1f)