### PR TITLE
(DOCSP-27483) Adds guidance to create Atlas search index from a file

### DIFF
--- a/source/includes/create-atlas-search-index-config-file.json
+++ b/source/includes/create-atlas-search-index-config-file.json
@@ -1,0 +1,8 @@
+{
+  "collectionName": "listingsAndReviews",
+  "database": "sample_airbnb",
+  "name": "myIndex",
+  "mappings": {
+    "dynamic": true
+  }
+}

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -102,8 +102,16 @@ To learn more about cloud backup schedule configuration files, see
 :ref:`atlas-cli-cloud-backup-schedule-config-file`. For a sample file,
 see :ref:`example-cloud-backup-schedule-config-file`.
 
+Atlas Search Index Configuration File
+-------------------------------------
+
+To learn more about |fts| index configuration files, see 
+:ref:`atlas-cli-search-index-config-file`. For a sample file,
+see :ref:`example-search-index-config-file`.
+
 .. toctree::
    :titlesonly:
 
    /reference/json/cluster-config-file
    /reference/json/cloud-backup-schedule-config-file
+   /reference/json/search-index-config-file

--- a/source/reference/json/search-index-config-file.txt
+++ b/source/reference/json/search-index-config-file.txt
@@ -10,8 +10,8 @@ Atlas Search Index Configuration File
    :depth: 1
    :class: singlecol
 
-You can use an |fts| configuration file to specify the settings
-required when you :ref:`create a search index
+You can use an |fts| index configuration file to specify the required 
+settings for :ref:`creating a search index
 <atlas-clusters-search-indexes-create>` using the {+atlas-cli+}. The 
 {+atlas-cli+} accepts ``.json`` search index configuration files.
 
@@ -35,13 +35,13 @@ the request body schema in the API specification:
 
    * - ``collectionName``
      - string
-     - Label that identifies the collection that contains one or more
-       |fts| indexes.
+     - Label that identifies the collection for which you want to
+       create an |fts| index.
 
    * - ``database``
      - string
      - Label that identifies the database that contains the collection
-       with one or more |fts| indexes.
+       for which you want to create an |fts| index.
 
    * - ``name``
      - string
@@ -55,8 +55,9 @@ the request body schema in the API specification:
    * - ``mappings.dynamic``
      - boolean
      - Flag that indicates whether the index uses dynamic or static
-       mappings. Required if ``mappings.fields`` is omitted. To learn
-       more, see :atlas:`atlas-search/index-definitions`.
+       mappings. If omitted or if set to ``false``, ``mappings.fields`` is required. To learn more, see 
+       :atlas:`Atlas Search Index Syntax 
+       </atlas-search/index-definitions/>`.
 
 
 .. _example-search-index-config-file:

--- a/source/reference/json/search-index-config-file.txt
+++ b/source/reference/json/search-index-config-file.txt
@@ -1,0 +1,87 @@
+.. _atlas-cli-search-index-config-file:
+
+=====================================
+Atlas Search Index Configuration File
+=====================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+You can use an |fts| configuration file to specify the settings
+required when you :ref:`create a search index
+<atlas-clusters-search-indexes-create>` using the {+atlas-cli+}. The 
+{+atlas-cli+} accepts ``.json`` search index configuration files.
+
+.. _search-index-settings:
+
+Atlas Search Index Settings
+---------------------------
+
+You can specify the following settings in the |fts| index
+configuration file. For a full list of available settings, see
+the request body schema in the API specification:
+:oas-atlas-op:`Create One Atlas Search Index </createAtlasSearchIndex>`.
+
+.. list-table:: 
+   :header-rows: 1 
+   :widths: 20 10 70 
+
+   * - Field 
+     - Type 
+     - Description 
+
+   * - ``collectionName``
+     - string
+     - Label that identifies the collection that contains one or more
+       |fts| indexes.
+
+   * - ``database``
+     - string
+     - Label that identifies the database that contains the collection
+       with one or more |fts| indexes.
+
+   * - ``name``
+     - string
+     - Label that identifies this index. Within each namespace, names
+       of all indexes in the namespace must be unique.
+
+   * - ``mappings``
+     - object
+     - Index specifications for the collection's fields.
+
+   * - ``mappings.dynamic``
+     - boolean
+     - Flag that indicates whether the index uses dynamic or static
+       mappings. Required if ``mappings.fields`` is omitted. To learn
+       more, see :atlas:`atlas-search/index-definitions`.
+
+
+.. _example-search-index-config-file:
+
+Example Atlas Search Index Configuration File
+---------------------------------------------
+
+To create an |fts| index, specify the search index details as shown in
+the following example file:
+
+.. literalinclude:: /includes/create-atlas-search-index-config-file.json
+
+Example Atlas Search Index Create Command
+-----------------------------------------
+
+After you create the file, run the command to create the |fts| search
+index and specify the ``clusterName`` and the ``file``. The
+following example creates a search index for the cluster named
+myCluster using a JSON index configuration file named 
+search-config.json:
+
+.. code-block::
+
+   atlas clusters search indexes create --clusterName myCluster --file search-config.json --output json
+
+
+
+


### PR DESCRIPTION
I tested this process with a file and confirmed that it successfully creates the index.

[Jira Ticket](https://jira.mongodb.org/browse/DOCSP-27483)
[Staging 1: top-level page for config files](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-27483/reference/json/)
[Staging 2: search index config file page](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-27483/reference/json/search-index-config-file/)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64837b4467a273b816e4edbc) All build errors are unrelated