### PR TITLE
(DOCSP-29595): Pulled in specific steps for API key access lists.

### DIFF
--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -90,9 +90,16 @@ to create new projects.
 The user's IP address or API key that you use to authenticate is not on
 the :atlas:`access list </configure-api-access>` for the requested
 project. Add your IP address or API key to the :atlas:`access list 
-</configure-api-access>` to run commands. To learn more, see 
-:atlas:`Get Started with the Atlas Administration API 
-</configure-api-access>`.
+</configure-api-access>` to run commands.
+
+To learn more, see the following pages:
+
+- For project access lists, see 
+  :atlas:`Configure IP Access List Entries </security/ip-access-list/>`.
+
+- For API key access lists, see 
+  :atlas:`Get Started with the Atlas Administration API 
+  </configure-api-access>`.
 
 To add your IP address to an API key's access list:
 

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -92,7 +92,7 @@ the :atlas:`access list </configure-api-access>` for the requested
 project. Add your IP address or API key to the :atlas:`access list 
 </configure-api-access>` to run commands. To learn more, see 
 :atlas:`Get Started with the Atlas Administration API 
-</configure-api-access>`.
+</configure-api-access>`. 
 
 To add your IP address to an API key's access list:
 

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -89,8 +89,52 @@ to create new projects.
 
 The user's IP address or API key that you use to authenticate is not on
 the :atlas:`access list </configure-api-access>` for the requested
-project. Add your IP address or API key to the
-:atlas:`access list </configure-api-access>` to run commands.
+project. Add your IP address or API key to the :atlas:`access list 
+</configure-api-access>` to run commands. To learn more, see 
+:atlas:`Get Started with the Atlas Administration API 
+</configure-api-access>`.
+
+To add your IP address to an API key's access list:
+
+.. procedure::
+   :style: normal
+
+   .. step:: Go to the :guilabel:`Access Manager` page for your project.
+
+      a. If it isn't already displayed, select the organization that
+         contains your desired project from the :icon-mms:`office` 
+         :guilabel:`Organizations` menu in the navigation bar.
+
+      #. Select your desired project from the list of projects in the 
+         :guilabel:`Projects` page.
+
+      #. Click the vertical ellipsis (:icon-fa4:`ellipsis-v`) next to 
+         your project name in the upper left corner and select 
+         :guilabel:`Project Settings`.
+
+      #. Click :guilabel:`Access Manager` in the navigation bar.
+
+   .. step:: Go to the API key's access list.
+
+      a. Click the :guilabel:`API Keys` tab.
+
+      #. Click :icon-mms:`ellipsis` to the right of the |api| Key.
+  
+      #. Click :guilabel:`Edit Permissions` and click :guilabel:`Next`.
+      
+   .. step:: Add your IP address to the API key's access list.
+
+      a. Do on of the following tasks in the 
+         :guilabel:`API Access List` section:
+
+         - Click :guilabel:`Add Access List Entry` and type an |ipaddr| 
+           address.
+
+         - If your current host for accessing |service| will also make 
+           |api| requests with this |api| key, click 
+           :guilabel:`Use Current IP Address` .
+
+      #. Click :guilabel:`Save`.
 
 404 (request "Not Found") An invalid group ID <group-id> was specified.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -108,8 +108,8 @@ To add your IP address to an API key's access list:
       #. Select your desired project from the list of projects in the 
          :guilabel:`Projects` page.
 
-      #. Click the vertical ellipsis (:icon-fa4:`ellipsis-v`) next to 
-         your project name in the upper left corner and select 
+      #. Next to the :guilabel:`Projects` menu, expand the
+         :icon-fa5:`ellipsis-v` :guilabel:`Options` menu, then click 
          :guilabel:`Project Settings`.
 
       #. Click :guilabel:`Access Manager` in the navigation bar.
@@ -124,7 +124,7 @@ To add your IP address to an API key's access list:
       
    .. step:: Add your IP address to the API key's access list.
 
-      a. Do on of the following tasks in the 
+      a. Do one of the following tasks in the 
          :guilabel:`API Access List` section:
 
          - Click :guilabel:`Add Access List Entry` and type an |ipaddr| 

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -87,9 +87,9 @@ to create new projects.
 403 (request "Forbidden") IP address <ip-address> is not allowed to access this resource.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The user's IP address or API key that you use to authenticate is not on
+The user's IP address that you use to authenticate is not on
 the :atlas:`access list </configure-api-access>` for the requested
-project. Add your IP address or API key to the :atlas:`access list 
+project. Add your IP address to the :atlas:`access list 
 </configure-api-access>` to run commands.
 
 To learn more, see the following pages:

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -92,7 +92,7 @@ the :atlas:`access list </configure-api-access>` for the requested
 project. Add your IP address or API key to the :atlas:`access list 
 </configure-api-access>` to run commands. To learn more, see 
 :atlas:`Get Started with the Atlas Administration API 
-</configure-api-access>`. 
+</configure-api-access>`.
 
 To add your IP address to an API key's access list:
 


### PR DESCRIPTION
@andreaangiolillo and @jwilliams-mongo, I added the specific steps or accessing the API key access list to the following troubleshooting page.

[STAGE](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-29595/troubleshooting/#403--request--forbidden---ip-address--ip-address--is-not-allowed-to-access-this-resource.)

[JIRA](https://jira.mongodb.org/browse/DOCSP-29595)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=648c797a259a8493e5f5b12e)