### PR TITLE
(DOCSP-31349) Adds deprecated Atlas CLI commands to v1.9 changelog.

### DIFF
--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -54,7 +54,7 @@ Released 29 June 2023
 - Fixes the :ref:`atlas-clusters-update` and :ref:`atlas-serverless-update`
   commands ignoring the ``--tag`` flag.
 - Deprecates ``atlas datalake`` and ``atlas privateEndpoints`` 
-  commands in favour of ``atlas datafederation``.
+  commands in favor of ``atlas datafederation``.
 
 .. _atlas-cli-1.8.0:
 

--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -53,9 +53,8 @@ Released 29 June 2023
 - Updates a namespace to be optional for performance advisor operations.
 - Fixes the :ref:`atlas-clusters-update` and :ref:`atlas-serverless-update`
   commands ignoring the ``--tag`` flag.
-
-- Deprecates ``atlas datalake`` commands in favour of ``atlas
-  datafederation``.
+- Deprecates ``atlas datalake`` and ``atlas privateEndpoints`` 
+  commands in favour of ``atlas datafederation``.
 
 .. _atlas-cli-1.8.0:
 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-31349)
[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b157f68d53f9c4af0c5647)
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-31349/atlas-cli-changelog/#atlas-cli-1.9.0)
