### PR TITLE
(DOCSP-30771) Adds Docker image as way to install Atlas CLI

### DIFF
--- a/source/atlas-cli-save-connection-settings.txt
+++ b/source/atlas-cli-save-connection-settings.txt
@@ -125,6 +125,7 @@ Select a use case and follow the procedure to create a profile.
             exists, these commands update the default profile's values.
 
             .. procedure::
+               :style: normal
 
                .. include:: /includes/steps-atlas-cli-auth-nonprog-default.rst
 
@@ -136,6 +137,7 @@ Select a use case and follow the procedure to create a profile.
             Follow these steps to create a profile with a custom name.
 
             .. procedure::
+               :style: normal
 
                .. step:: Run the authentication command.
 
@@ -166,6 +168,7 @@ Select a use case and follow the procedure to create a profile.
             exists, these commands update the default profile's values.
 
             .. procedure::
+               :style: normal
 
                .. include:: /includes/steps-atlas-cli-auth-prog-default.rst
 
@@ -177,6 +180,7 @@ Select a use case and follow the procedure to create a profile.
             Follow these steps to create a profile with a custom name.
 
             .. procedure::
+               :style: normal
 
                .. step:: Run the authentication command.
 

--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -124,6 +124,7 @@ from the {+atlas-cli+}.
       :tabid: atlas-auth-login
 
       .. procedure::
+         :style: normal
 
          .. include:: /includes/steps-atlas-cli-auth-nonprog-default.rst
 
@@ -185,6 +186,7 @@ from the {+atlas-cli+}.
       :tabid: atlas-config-init
 
       .. procedure::
+         :style: normal
 
          .. include:: /includes/steps-atlas-cli-auth-prog-default.rst
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -411,16 +411,11 @@ Follow These Steps
 
       .. code-block::
 
-         docker pull mongodb/atlas-cli
+         docker pull mongodb/atlas
 
-      After you pull the {+atlas-cli+} Docker image, you can run
-      {+atlas-cli+} commands with Docker. 
-      
-      To run an {+atlas-cli+} command with Docker, add 
-      ``docker run --rm atlas-cli`` before the
-      {+atlas-cli+} command. For example, to run the
-      :ref:`atlas-clusters-list` command with Docker, run 
-      ``docker run --rm atlas-cli atlas clusters list``.
+      To learn how to run {+atlas-cli+} commands with Docker, see the
+      `{+atlas-cli+} Docker documentation 
+      <https://hub.docker.com/repository/docker/mongodb/atlas/general>`__.
 
    .. tab:: Download Binary
       :tabid: download-binary

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -66,6 +66,16 @@ To check whether your operating system is compatible with the
       #. Install Chocolatey using ``cmd.exe`` or ``PowerShell.exe``. To 
          learn more, see `Installing Chocolatey <https://docs.chocolatey.org/en-us/choco/setup#installing-chocolatey>`__.
 
+   .. tab:: Docker
+      :tabid: docker
+
+      Complete the Prerequisites
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      To install the {+atlas-cli+} using Docker, install the 
+      `Docker engine <https://docs.docker.com/engine/install/>`__ or
+      `Docker desktop <https://docs.docker.com/desktop/>`__.
+
    .. tab:: Download Binary
       :tabid: download-binary
 
@@ -79,6 +89,7 @@ Follow These Steps
       :tabid: Homebrew
 
       .. procedure::
+         :style: normal
 
          .. step:: Install the {+atlas-cli+} and {+mongosh+}.
 
@@ -101,6 +112,7 @@ Follow These Steps
       :tabid: yum    
       
       .. procedure::
+         :style: normal
 
          .. step:: Configure ``yum`` for your edition of MongoDB. 
 
@@ -202,6 +214,7 @@ Follow These Steps
       :tabid: apt
 
       .. procedure::
+         :style: normal
 
          .. step:: Import the public key used by ``apt``.
 
@@ -376,6 +389,7 @@ Follow These Steps
       :tabid: chocolatey
 
       .. procedure::
+         :style: normal
 
          .. step:: Install the {+atlas-cli+}.
 
@@ -389,10 +403,30 @@ Follow These Steps
 
          .. include:: /includes/steps-verify-atlas-cli.rst
 
+   .. tab:: Docker
+      :tabid: docker
+
+      To pull the latest {+atlas-cli+} Docker image, run the following
+      command:
+
+      .. code-block::
+
+         docker pull mongodb/atlas-cli
+
+      After you pull the {+atlas-cli+} Docker image, you can run
+      {+atlas-cli+} commands with Docker. 
+      
+      To run an {+atlas-cli+} command with Docker, add 
+      ``docker run --rm atlas-cli`` before the
+      {+atlas-cli+} command. For example, to run the
+      :ref:`atlas-clusters-list` command with Docker, run 
+      ``docker run --rm atlas-cli atlas clusters list``.
+
    .. tab:: Download Binary
       :tabid: download-binary
 
       .. procedure::
+         :style: normal
 
          .. step:: Install the {+atlas-cli+}.
           
@@ -452,6 +486,7 @@ method you used to install the {+atlas-cli+}:
       ~~~~~~~~~~~~~~~~~~
 
       .. procedure::
+         :style: normal
 
          .. step:: Update the {+atlas-cli+}.
 
@@ -480,6 +515,7 @@ method you used to install the {+atlas-cli+}:
       ~~~~~~~~~~~~~~~~~~
 
       .. procedure::
+         :style: normal
 
          .. step:: Update the {+atlas-cli+}.
 
@@ -506,6 +542,7 @@ method you used to install the {+atlas-cli+}:
       ~~~~~~~~~~~~~~~~~~
 
       .. procedure::
+         :style: normal
 
          .. step:: Update the {+atlas-cli+}.
 
@@ -533,6 +570,7 @@ method you used to install the {+atlas-cli+}:
       ~~~~~~~~~~~~~~~~~~
 
       .. procedure::
+         :style: normal
 
          .. step:: Install the {+atlas-cli+}.
 
@@ -549,6 +587,7 @@ method you used to install the {+atlas-cli+}:
       ~~~~~~~~~~~~~~~~~~
 
       .. procedure::
+         :style: normal
 
          .. step:: Update the {+atlas-cli+}.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -413,7 +413,19 @@ Follow These Steps
 
          docker pull mongodb/atlas
 
-      To learn how to run {+atlas-cli+} commands with Docker, see the
+      If you run ``docker pull mongodb/atlas`` without specifying
+      a version tag, Docker automatically pulls the latest version
+      of the Docker image (``mongodb/atlas:latest``). 
+      
+      To pull a specific version of the Docker image, run the following
+      command, replacing ``<tag>`` with the version tag: 
+      
+      .. code-block::
+      
+         docker pull mongodb/atlas:<tag>
+
+      To learn how to run {+atlas-cli+} commands with Docker after you
+      pull the Docker image, see the
       `{+atlas-cli+} Docker documentation 
       <https://hub.docker.com/repository/docker/mongodb/atlas/general>`__.
 

--- a/source/migrate-to-atlas-cli.txt
+++ b/source/migrate-to-atlas-cli.txt
@@ -21,6 +21,7 @@ Complete the
 following steps to migrate from the {+mcli+} to the {+atlas-cli+}:
 
 .. procedure::
+   :style: normal
 
    .. step:: Install the {+atlas-cli+}.
 


### PR DESCRIPTION
Aside from adding the Docker image as a way to install the Atlas CLI, this corrects the style of procedures in this repo to normal style.

[Jira](https://jira.mongodb.org/browse/DOCSP-30771)
[Staging (Docker tab)](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-30771/install-atlas-cli/#install-the-atlas-cli)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bfeaed87b3b36046d6e57c)