### PR TITLE
(DOCSP-32120) Adds local deployment for the Atlas CLI

### DIFF
--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -1,0 +1,85 @@
+.. _atlas-cli-local-cloud:
+
+=========================================================
+Manage Local and Cloud Deployments from the {+atlas-cli+}
+=========================================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+With the ``atlas deployments`` commands, you can perform the following
+actions with the {+atlas-cli+}:
+
+- Create local MongoDB deployments. Local deployments reside on your
+  computer and provide a non-production environment for development.
+- Create |service| cloud deployments. |service| hosts deployments in
+  the cloud for both non-production and production use.
+- Manage local {+clusters+} that you deployed with ``atlas
+  deployments``.
+- Manage all MongoDB |service| cloud deployments.
+
+.. note::
+
+   For local MongoDB deployments, you can manage only deployments that
+   you created with ``atlas deployments``. If you created a local
+   MongoDB {+cluster+} without using the {+atlas-cli+}, you can't
+   manage that {+cluster+} with the {+atlas-cli+}.
+
+Only ``atlas deployments`` {+atlas-cli+} commands work on local MongoDB
+deployments. All {+atlas-cli+} commands, including ``atlas
+deployments`` commands, work on MongoDB |service| cloud deployments.
+
+Supported Actions
+-----------------
+
+The actions you can perform with ``atlas deployments`` include but
+aren't limited to:
+
+- **Set up** a new local or |service| cloud {+cluster+}, including:
+
+  - Create the {+cluster+}.
+  - Load sample data into the {+cluster+}.
+  - Add your IP address to your project's IP access list (for |service|
+    cloud {+clusters+} only).
+  - Create a MongoDB user for your {+cluster+}.
+  - Connect to your {+cluster+}.
+- **List** local and |service| cloud {+clusters+}.
+- **Connect** or return the connection string for a local or |service|
+  cloud {+cluster+}.
+- **Pause/Start** a local or |service| cloud {+cluster+}.
+- **Delete** a local or |service| cloud {+cluster+}.
+- **Access logs** for a local or |service| cloud {+cluster+}.
+- **Create/manage search indexes** to run |service| Search on a
+  local or |service| cloud {+cluster+}.
+
+To learn all of the actions that ``atlas deployments`` supports, see
+:ref:`atlas-deployments`.
+
+Tutorials
+---------
+
+Use the following resources for step-by-step guidance to run ``atlas
+deployments`` commands:
+
+.. list-table:: 
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Tutorial
+     - Objective
+
+   * - :ref:`atlas-cli-deploy-local`
+     - Use the ``atlas deployments`` command to create a local MongoDB
+       {+cluster+}. This tutorial deploys a single-node replica set on
+       your local computer.
+
+
+.. toctree::
+   :titlesonly:
+
+   /atlas-cli-deploy-local

--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -39,6 +39,11 @@ You can also go straight to the :doc:`{+atlas-cli+} Commands
        {+cluster+}. This tutorial requires an |service| account and an
        existing organization.
 
+   * - :ref:`atlas-cli-local-cloud`
+     - Find tutorials for the ``atlas deployments`` command, which lets
+       you create local MongoDB deployments, create |service| cloud
+       deployments, manage local {+clusters+} that you deployed with ``atlas deployments``, and manage all MongoDB |service| cloud deployments.
+
    * - :ref:`atlas-cli-ephemeral-cluster`
      - Create an ephemeral project and {+cluster+} to test automations.
 
@@ -49,4 +54,5 @@ You can also go straight to the :doc:`{+atlas-cli+} Commands
    /atlas-cli-getting-started
    /atlas-cli-quickstart
    /atlas-cli-create-cluster-from-config-file
+   /atlas-cli-local-cloud
    /atlas-cli-ephemeral-cluster


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-32120)
[Staging 1: top-level tutorial page](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-32120/atlas-cli-tutorials/)
[Staging 2: new sub-level tutorial page just for ``atlas deployments`` commands](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-32120/atlas-cli-local-cloud/)
[Staging 3: tutorial for local deployment]()
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64df87e357e37806c5438040)
