### PR TITLE
(DOCSP-32541): Fix broken Atlas links

### DIFF
--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -67,11 +67,11 @@ a ``401`` error will result.
 The user account or API key that you used to 
 :ref:`connect to the {+atlas-cli+} <connect-atlas-cli>`
 doesn't have permission to perform the requested action. User accounts
-and API keys must have the appropriate :atlas:`user roles <user-roles>`
+and API keys must have the appropriate :atlas:`user roles </reference/user-roles>`
 to run {+atlas-cli+} commands. To assign or change a user's roles, see: 
 
-- :atlas:`add-org-users`
-- :atlas:`manage-project-access`
+- :atlas:`Manage Organization Users </access/manage-org-users/>`
+- :atlas:`Manage Access to a Project </access/manage-project-access/>`
 - :atlas:`API configuration </configure-api-access>`
 
 401 (request "Unauthorized") The currently logged in user does not have the group creator role in organization <org-id>.


### PR DESCRIPTION
Accidentally closed https://github.com/mongodb/docs-atlas-cli/pull/196 after some git mishaps - creating and merging this separate PR

[Jira](https://jira.mongodb.org/browse/DOCSP-32541)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e504f657e37806c54ebbd9)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-32541/troubleshooting/)