### PR TITLE
(DOCSP-32865): Add details for config files for alert configurations

### DIFF
--- a/source/includes/alert-configuration-config-file.json
+++ b/source/includes/alert-configuration-config-file.json
@@ -1,0 +1,26 @@
+{
+  "enabled": true,
+  "eventTypeName": "NO_PRIMARY",
+  "matchers": [
+    {
+      "fieldName": "REPLICA_SET_NAME",
+      "operator": "EQUALS",
+      "value": "event-replica-set"
+    }
+  ],
+  "notifications": [
+    {
+      "datadogApiKey": "****************************a23c",
+      "datadogRegion": "US",
+      "delayMin": 0,
+      "intervalMin": 5,
+      "notifierId": "6462742adc47d365036da07c",
+      "typeName": "DATADOG"
+    }
+  ],
+  "threshold": {
+    "operator": "<",
+    "threshold": 0,
+    "units": "bits"
+  }
+}

--- a/source/reference/json.txt
+++ b/source/reference/json.txt
@@ -20,6 +20,8 @@ you can pass a configuration file when using the {+atlas-cli+} to:
 - :ref:`Create <atlas-clusters-search-indexes-create>` or 
   :ref:`update an Atlas Search Index <atlas-clusters-search-indexes-update>`.
 - :ref:`Create a {+df+} database <atlas-dataFederation-create>`.
+- :ref:`Create <atlas-alerts-settings-create>` or 
+  :ref:`update an alert configuration <atlas-alerts-settings-update>`.
 
 Usage
 -----
@@ -56,6 +58,12 @@ command. The commands you can use include but are not limited to:
 
   * - :ref:`atlas-dataFederation-create`
     - :oas-atlas-op:`Create One Federated Database Instance in One Project </createFederatedDatabase>`
+
+  * - :ref:`atlas-alerts-settings-create`
+    - :oas-atlas-op:`Create One Alert Configuration in One Project </createAlertConfiguration>`
+
+  * - :ref:`atlas-alerts-settings-update`
+    - :oas-atlas-op:`Update One Alert Configuration for One Project </updateAlertConfiguration>`
 
 When you run the command in your terminal, specify the ``--file`` option 
 and provide the path to the |json| configuration file that defines your 
@@ -120,6 +128,13 @@ To learn more about {+adf+} configuration files, see
 :ref:`atlas-cli-data-federation-config-file`. For a sample file,
 see :ref:`example-fdi-config-file`.
 
+Alert Configuration File
+------------------------
+
+To learn more about alert configuration files, see 
+:ref:`atlas-cli-alert-config-file`. For a sample file,
+see :ref:`example-alert-config-file`.
+
 .. toctree::
    :titlesonly:
 
@@ -127,3 +142,4 @@ see :ref:`example-fdi-config-file`.
    /reference/json/cloud-backup-schedule-config-file
    /reference/json/data-federation-config-file
    /reference/json/search-index-config-file
+   /reference/json/alert-config-file

--- a/source/reference/json/alert-config-file.txt
+++ b/source/reference/json/alert-config-file.txt
@@ -80,3 +80,34 @@ configuration that notifies you when a replica set called
 ``event-replica-set`` loses its primary node:
 
 .. literalinclude:: /includes/alert-configuration-config-file.json
+
+Example Alert Configuration Commands
+------------------------------------
+
+After you create the file, run the {+atlas-cli+} 
+command to create or update the alert configuration.
+
+Create an Alert Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To create an alert configuration, specify the ``--flag`` option 
+and the path to the file. The following example creates an 
+alert configuration by using a configuration file named 
+``alert-config.json``:
+
+.. code-block::
+
+   atlas alerts settings create --file /alert-config.json
+
+Update an Alert Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update an alert configuration, specify the ID of the
+alert configuration that you want to update, the ``--flag``
+option, and the path to the file. The following example updates 
+an existing alert configuration by using a configuration file 
+named ``alert-config.json``:
+
+.. code-block::
+
+   atlas alerts settings update <alertConfigId> --file /alert-config.json

--- a/source/reference/json/alert-config-file.txt
+++ b/source/reference/json/alert-config-file.txt
@@ -1,0 +1,82 @@
+.. _atlas-cli-alert-config-file:
+
+========================
+Alert Configuration File
+========================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+You can use a configuration file to specify the
+settings for :ref:`creating <atlas-alerts-settings-create>`
+or :ref:`updating <atlas-alerts-settings-update>` an alert
+configuration through the {+atlas-cli+}. The {+atlas-cli+}
+accepts ``.json`` configuration files.
+
+.. _alert-config-settings:
+
+Alert Configuration Settings
+----------------------------
+
+Depending on the type of alert configuration, you can specify the 
+following settings to create or update an alert configuration 
+in a configuration file:
+
+.. list-table::
+   :widths: 20 10 70
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+
+   * - ``enabled``
+     - boolean
+     - Flag that indicates whether someone enabled this
+       alert configuration for the specified project.
+
+   * - ``eventTypeName``
+     - string
+     - Required. Event type that triggers an alert.
+
+   * - ``matchers``
+     - array of objects
+     - Rules to apply when matching an object against this alert
+       configuration. You can use this field only if the ``eventTypeName``
+       specifies an event for a host, replica set, or sharded cluster.
+
+   * - ``metricThreshold``
+     - object
+     - Threshold for the metric that, when exceeded, triggers an alert.
+       You can use this field only if the ``eventTypeName`` reflects
+       a change in measurement or metric.
+
+   * - ``notifications``
+     - array of objects
+     - List that contains the targets that |service| sends notifications.
+
+   * - ``threshold``
+     - object
+     - A limit that triggers an alert when exceeded.
+
+For detailed descriptions and a full list of available settings,
+see the request body schema in the API specification:
+
+- :oas-atlas-op:`Create One Alert Configuration in One Project </createAlertConfiguration>`
+- :oas-atlas-op:`Update One Alert Configuration for One Project </updateAlertConfiguration>`
+
+.. _example-alert-config-file:
+
+Example Alert Configuration File
+--------------------------------
+
+To create or update an alert configuration, specify the
+fields that you want to include in the configuration file.
+For example, the following sample file enables an alert 
+configuration that notifies you when a replica set called 
+``event-replica-set`` loses its primary node:
+
+.. literalinclude:: /includes/alert-configuration-config-file.json

--- a/source/reference/json/search-index-config-file.txt
+++ b/source/reference/json/search-index-config-file.txt
@@ -81,7 +81,7 @@ search-config.json:
 
 .. code-block::
 
-   atlas clusters search indexes create --clusterName myCluster --file search-config.json --output json
+   atlas clusters search indexes create --clusterName myCluster --file /search-config.json --output json
 
 
 


### PR DESCRIPTION
Question for reviewers: How descriptive do we want to be for the settings on this page? I erred on the conservative side to encourage users to use the Open API spec since the descriptions are much more detailed and extensive there. Let me know what you think.
  
## Description
`atlas alerts settings create` and `atlas alerts settings update` now support the `--file` option for a JSON configuration file input.

## Links
[Jira](https://jira.mongodb.org/browse/DOCSP-32865)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64fb629e24fcc731b47cc592)

### Staging
- [JSON](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-32865/reference/json/)
- [Alert Configuration File](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-32865/reference/json/alert-config-file/)
