### PR TITLE
updated facets.toml file for correct product/subproduct

### DIFF
--- a/source/facets.toml
+++ b/source/facets.toml
@@ -1,3 +1,7 @@
 [[facets]]
 category = "target_product"
+value = "atlas"
+
+[[facets.sub_facets]]
+category = "sub_product"
 value = "atlas-cli"


### PR DESCRIPTION
Hey @jwilliams-mongo!

You identified on an earlier PR that the facet.toml file for the Atlas CLI repo had the wrong product name.  Seung updated the facets.csv file and I re-ran the script on this repo to update the toml file with the correct values.

Here's the [build log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65241f09885de6b26bd66b5e) & the [preview link](https://preview-mongodbsarahemlin.gatsbyjs.io/atlas-cli/facet-toml-update/).  The log didn't have errors, but it did make me wonder because it listed zero files modified and 981 files created, which is not what I expected.

Thank you!
Sarah