### PR TITLE
Revert "(DOCSP-33582): Removed rst syntax from code example."

### DIFF
--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -244,8 +244,11 @@ mode.
             Specify ``myLocalRs`` and press ``Enter``.
 
             .. code-block:: sh
+                
+               .. input::
+                  :language: sh
             
-               ? Deployment Name [This can't be changed later] (local3612) myLocalRs
+                  ? Deployment Name [This can't be changed later] (local3612) myLocalRs
 
          .. step:: Specify a MongoDB Version.
 


### PR DESCRIPTION
Reverts mongodb/docs-atlas-cli#215. [BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65259f71885de6b26b46be2c)