### PR TITLE
(DOCSP-33498): Added deploy and search to landing page.

### DIFF
--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -395,7 +395,7 @@ deployment.
 
       #. Specify ``y`` and press ``Enter`` to confirm.
 
-.. _atlas-cli-deploy-local-fts:
+.. _atlas-cli-deploy-fts:
 
 Use Atlas Search with a Local Atlas Deployment
 ----------------------------------------------

--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -62,7 +62,7 @@ command  for local and cloud |service| deployments including, but not limited to
 - :ref:`Delete an Atlas deployment <atlas-cli-deploy-local-manage>`.
   
 - :ref:`Create or manage Atlas Search indexes 
-  <atlas-cli-deploy-local-fts>` to run a full-text search on an 
+  <atlas-cli-deploy-fts>` to run a full-text search on an 
   |service| deployment.
  
 - :ref:`Create or manage {+avs+} indexes <atlas-cli-deploy-local-avs>` 

--- a/source/index.txt
+++ b/source/index.txt
@@ -71,6 +71,23 @@ Get started quickly with two commands:
       .. image:: /images/setup.gif
          :alt: atlas setup command
 
+   .. tab:: Create an Atlas Deployment
+      :tabid: deploy
+
+      .. procedure::
+
+         .. step:: Run ``atlas deployments setup``
+
+            To learn more, see :ref:`atlas-cli-local-cloud`.
+
+   .. tab:: Create an Atlas Search Index
+      :tabid: search
+
+      .. procedure::
+
+         .. step:: Run ``atlas deployments search indexes create``
+
+            To learn more, see :ref:`atlas-cli-deploy-fts`.
 
 .. kicker:: Related Products & Resources
 


### PR DESCRIPTION
@boooczek and @lmkerbey-mdb, I updated to the landing page to include tabs for creating deployments and Atlas Search indexes. When I break the Atlas Search sections out of the local deployment tutorial, the link will go to the new page.

[STAGE](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-33498/#manage-atlas-from-the-command-line)

[JIRA](https://jira.mongodb.org/browse/DOCSP-33498)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65297eb1673b813c8f47a704)