### PR TITLE
(DOCSP-33494): Added MongoDB Tools prereq.

### DIFF
--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -88,6 +88,15 @@ Before you begin, complete the following prerequisites:
 
      brew install mongodb-compass
 
+- Install :dbtools:`MongoDB Database Tools 
+  </installation/installation/>`.
+
+  **Example:**
+
+  .. code-block:: sh
+
+     brew install mongodb-database-tools
+
 - Install `Podman <https://podman.io/>`__ version 4.4 and later.
 
   **Example:**


### PR DESCRIPTION
I added the MongoDB Tools prereq to the following page.

[STAGE](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-33494/atlas-cli-deploy-local/#complete-the-prerequisites)

[JIRA](https://jira.mongodb.org/browse/DOCSP-33494)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=652ec220673b813c8f63ebb7)