### PR TITLE
(DOCSP-34098)(DOCSP-34247): Updated local tutorial and search tutorial.

### DIFF
--- a/source/atlas-cli-deploy-fts.txt
+++ b/source/atlas-cli-deploy-fts.txt
@@ -394,20 +394,15 @@ Search </atlas-search/field-types/knn-vector>`.
       .. code-block:: json
 
          {
-           "collectionName": "embedded_movies",
-           "database": "sample_mflix",  
-           "mappings": {
-             "dynamic": true,
-             "fields": {
-               "plot_embedding": {
-                 "type": "knnVector",
-                 "dimensions": 1536,
-                 "similarity": "euclidean"
-               }
-             }
-           },
-           "name": "vectorSearchIndex"
-         }
+           "name": "vectorSearchIndex",
+           "type": "vectorSearch",
+           "fields": [{
+             "type": "vector",
+             "path": "plot_embedding",
+             "numDimensions": 1536,
+             "similarity": "euclidean"
+            }]
+          }
    
    .. step:: Create an |fts| index.
 

--- a/source/atlas-cli-deploy-fts.txt
+++ b/source/atlas-cli-deploy-fts.txt
@@ -95,16 +95,16 @@ mode.
 
                   atlas deployments search indexes create
 
-            #. Specify the deployment and press ``Enter``.
+            #. Specify the deployment and press :kbd:`Enter`..
 
             #. Specify ``searchIndex`` as the name for the index 
-               and press ``Enter``.
+               and press :kbd:`Enter`..
             
             #. Specify the ``sample_mflix`` database and press 
-               ``Enter``.
+               :kbd:`Enter`..
 
             #. Specify the ``movies`` collection and press 
-               ``Enter``.
+               :kbd:`Enter`..
 
          .. step:: Connect to the deployment.
 
@@ -115,9 +115,9 @@ mode.
                   atlas deployments connect
       
             #. Specify the deployment to connect to and press 
-               ``Enter``.
+               :kbd:`Enter`..
 
-            #. Specify ``mongosh`` and press ``Enter``.
+            #. Specify ``mongosh`` and press :kbd:`Enter`..
 
          .. step:: Switch to the ``sample_mflix`` database.
 
@@ -205,9 +205,9 @@ mode.
                   atlas deployments connect
       
             #. Specify the deployment to connect to and press 
-               ``Enter``.
+               :kbd:`Enter`..
 
-            #. Specify ``mongosh`` and press ``Enter``.
+            #. Specify ``mongosh`` and press :kbd:`Enter`..
 
          .. step:: Switch to the ``sample_mflix`` database.
 
@@ -298,7 +298,7 @@ mode.
 
                   atlas deployments search indexes create --file indexDef.json
 
-            #. Specify the deployment and press ``Enter``.
+            #. Specify the deployment and press :kbd:`Enter`..
 
          .. step:: Connect to the deployment.
 
@@ -309,9 +309,9 @@ mode.
                   atlas deployments connect
       
             #. Specify the deployment to connect to and press 
-               ``Enter``.
+               :kbd:`Enter`..
 
-            #. Specify ``mongosh`` and press ``Enter``.
+            #. Specify ``mongosh`` and press :kbd:`Enter`..
 
          .. step:: Switch to the ``sample_mflix`` database.
 
@@ -396,13 +396,17 @@ Search </atlas-search/field-types/knn-vector>`.
          {
            "name": "vectorSearchIndex",
            "type": "vectorSearch",
-           "fields": [{
-             "type": "vector",
-             "path": "plot_embedding",
-             "numDimensions": 1536,
-             "similarity": "euclidean"
-            }]
-          }
+           "collectionName": "embedded_movies",
+           "database": "sample_mflix",
+           "fields": [
+             {
+               "type": "vector",
+               "path": "plot_embedding",
+               "numDimensions": 1536,
+               "similarity": "euclidean"
+             }
+           ]
+         }
    
    .. step:: Create an |fts| index.
 
@@ -412,7 +416,7 @@ Search </atlas-search/field-types/knn-vector>`.
 
             atlas deployments search indexes create --file indexDef-vector.json
 
-      #. Specify the deployment and press ``Enter``.
+      #. Specify the deployment and press :kbd:`Enter`..
 
    .. step:: Connect to the deployment.
 
@@ -423,9 +427,9 @@ Search </atlas-search/field-types/knn-vector>`.
             atlas deployments connect
       
       #. Specify the deployment to connect to and press 
-         ``Enter``.
+         :kbd:`Enter`..
 
-      #. Specify ``mongosh`` and press ``Enter``.
+      #. Specify ``mongosh`` and press :kbd:`Enter`..
 
    .. step:: Switch to the ``sample_mflix`` database.
 

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -275,7 +275,10 @@ Manage a Local Atlas Deployment
 -------------------------------
 
 Use the ``atlas deployments`` command to manage a local |service| 
-deployment. 
+deployment. You can use the following commands for both local and 
+cloud |service| deployments. You can use ``--type local`` or 
+``--type cloud`` to run the command specifically for local or cloud 
+atlas deployments.
 
 .. procedure::
    :style: normal
@@ -330,6 +333,36 @@ deployment.
       #. Specify how you want to connect to the deployment and press 
          ``Enter``.
 
+   .. step:: Pause a deployment.
+
+      a. Run the following command to pause a deployment:
+
+         .. code-block:: sh
+
+            atlas deployments pause
+
+      #. Specify the deployment to pause and press ``Enter``.
+
+   .. step:: Start a deployment
+
+      a. Run the following command to start a deployment:
+
+         .. code-block:: sh
+
+            atlas deployments start
+      
+      #. Specify the deployment to start and press ``Enter``.
+
+   .. step:: Return the logs for the deployment.
+
+      a. Run the following command to start a deployment:
+
+         .. code-block:: sh
+
+            atlas deployments logs
+      
+      #. Specify the deployment to return logs for and press ``Enter``.
+
    .. step:: Delete a deployment.
 
       a. Run the following command to delete a deployment:
@@ -338,6 +371,8 @@ deployment.
 
             atlas deployments delete
 
+      #. Specify the deployment to delete and press ``Enter``. 
+   
       #. Specify ``y`` and press ``Enter`` to confirm.
 
 .. _atlas-cli-deploy-local-fts:

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -95,7 +95,7 @@ mode.
 
             **Example:**
 
-            Specify ``local - Local Database`` and press ``Enter``.
+            Specify ``local - Local Database`` and press :kbd:`Enter`..
 
             .. io-code-block::
 
@@ -119,7 +119,7 @@ mode.
             **Example:**
 
             Specify ``default - With default settings`` and press 
-            ``Enter``.
+            :kbd:`Enter`..
 
             .. io-code-block::
                 
@@ -156,7 +156,7 @@ mode.
 
          .. step:: Specify what to deploy.
 
-            Specify ``local - Local Database`` and press ``Enter``.
+            Specify ``local - Local Database`` and press :kbd:`Enter`..
 
             **Example:**
 
@@ -182,7 +182,7 @@ mode.
             **Example:**
 
             Specify ``custom - With custom settings`` and press 
-            ``Enter``.
+            :kbd:`Enter`..
 
             .. code-block:: sh
                 
@@ -195,7 +195,7 @@ mode.
 
             **Example:**
 
-            Specify ``myLocalRs`` and press ``Enter``.
+            Specify ``myLocalRs`` and press :kbd:`Enter`..
 
             .. code-block:: sh
             
@@ -205,7 +205,7 @@ mode.
 
             **Example:**
 
-            Specify ``7.0`` and press ``Enter``.
+            Specify ``7.0`` and press :kbd:`Enter`..
 
             .. code-block:: sh
             
@@ -217,7 +217,7 @@ mode.
 
             **Example:**
 
-            Specify ``37018`` and press ``Enter``.
+            Specify ``37018`` and press :kbd:`Enter`..
 
             .. io-code-block::
                 
@@ -277,8 +277,8 @@ Manage a Local Atlas Deployment
 Use the ``atlas deployments`` command to manage a local |service| 
 deployment. You can use the following commands for both local and 
 cloud |service| deployments. You can use ``--type local`` or 
-``--type cloud`` to run the command specifically for local or cloud 
-atlas deployments.
+``--type atlas`` to run the command for local or cloud 
+atlas deployments respectively.
 
 .. procedure::
    :style: normal
@@ -328,10 +328,10 @@ atlas deployments.
 
             atlas deployments connect
       
-      #. Specify the deployment to connect to and press ``Enter``.
+      #. Specify the deployment to connect to and press :kbd:`Enter`..
 
       #. Specify how you want to connect to the deployment and press 
-         ``Enter``.
+         :kbd:`Enter`..
 
    .. step:: Pause a deployment.
 
@@ -341,7 +341,7 @@ atlas deployments.
 
             atlas deployments pause
 
-      #. Specify the deployment to pause and press ``Enter``.
+      #. Specify the deployment to pause and press :kbd:`Enter`..
 
    .. step:: Start a deployment
 
@@ -351,17 +351,17 @@ atlas deployments.
 
             atlas deployments start
       
-      #. Specify the deployment to start and press ``Enter``.
+      #. Specify the deployment to start and press :kbd:`Enter`..
 
    .. step:: Return the logs for the deployment.
 
-      a. Run the following command to start a deployment:
+      a. Run the following command to return the logs for a deployment:
 
          .. code-block:: sh
 
             atlas deployments logs
       
-      #. Specify the deployment to return logs for and press ``Enter``.
+      #. Specify the deployment to return logs for and press :kbd:`Enter`..
 
    .. step:: Delete a deployment.
 
@@ -371,9 +371,9 @@ atlas deployments.
 
             atlas deployments delete
 
-      #. Specify the deployment to delete and press ``Enter``. 
+      #. Specify the deployment to delete and press :kbd:`Enter`.. 
    
-      #. Specify ``y`` and press ``Enter`` to confirm.
+      #. Specify ``y`` and press :kbd:`Enter`. to confirm.
 
 .. _atlas-cli-deploy-local-fts:
 

--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -41,7 +41,7 @@ actions:
    manage that deployment with the {+atlas-cli+}.
 
 You can use only ``atlas deployments`` {+atlas-cli+} commands with 
-local |service| deployments. You can use all other {+atlas-cli+} 
+local |service| deployments. You can use all {+atlas-cli+} 
 commands, including ``atlas deployments`` commands,  with cloud 
 |service| deployments.
 

--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -41,9 +41,9 @@ actions:
    manage that deployment with the {+atlas-cli+}.
 
 You can use only ``atlas deployments`` {+atlas-cli+} commands with 
-local |service| deployments and cloud deployments. You can use all 
-other {+atlas-cli+} commands, including ``atlas deployments`` 
-commands,  with cloud |service| deployments.
+local |service| deployments. You can use all other {+atlas-cli+} 
+commands, including ``atlas deployments`` commands,  with cloud 
+|service| deployments.
 
 Supported Actions
 -----------------

--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -41,9 +41,9 @@ actions:
    manage that deployment with the {+atlas-cli+}.
 
 You can use only ``atlas deployments`` {+atlas-cli+} commands with 
-local |service| deployments. You can use all {+atlas-cli+} commands, 
-including ``atlas deployments`` commands,  with cloud |service| 
-deployments.
+local |service| deployments and cloud deployments. You can use all 
+other {+atlas-cli+} commands, including ``atlas deployments`` 
+commands,  with cloud |service| deployments.
 
 Supported Actions
 -----------------


### PR DESCRIPTION
I updated the local tutorial and search tutorial for recent changes to the Atlas CLI and the upcoming vector search index change.

[Local Tutorial](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-34098/atlas-cli-deploy-local/#manage-a-local-atlas-deployment)

[Search Tutorial](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-34098/atlas-cli-deploy-fts/#use-atlas-vector-search-with-a-atlas-deployment)

https://jira.mongodb.org/browse/DOCSP-34098
https://jira.mongodb.org/browse/DOCSP-34247

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c526fe6b2f17c95a3edfe8)