### PR TITLE
DOCSP-34513 Add support for Debian 12

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -23,7 +23,7 @@ systems:
      - 2
      - ``x86-64``, ``ARM``
    * - Debian
-     - 10, 11
+     - 10, 11, 12
      - ``x86-64``, ``ARM``
    * - MacOS
      - 10.0 and later

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -294,6 +294,13 @@ Follow These Steps
 
                         .. tabs::
 
+                           .. tab:: Debian 12 (Bookworm)
+                              :tabid: comm-deb-12
+
+                              .. code-block:: sh
+
+                                 echo "deb http://repo.mongodb.org/apt/debian bookworm/mongodb-org/{+mdbVersion+} main" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+
                            .. tab:: Debian 11 (Bullseye)
                               :tabid: comm-deb-11
 


### PR DESCRIPTION
- https://jira.mongodb.org/browse/DOCSP-34513
- Stage:
  - [Install](https://preview-mongodbkanchanamongodb.gatsbyjs.io/atlas-cli/DOCSP-34513/install-atlas-cli/)
  - [Compatibility](https://preview-mongodbkanchanamongodb.gatsbyjs.io/atlas-cli/DOCSP-34513/compatibility/)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=656e42e47a5cb5fef5cd27ba)