### PR TITLE
(DOCSP-34859): Added local deploy in docker.

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -1,0 +1,148 @@
+.. _atlas-cli-deploy-docker:
+
+=========================================
+Create a Local Atlas Deployment in Docker
+=========================================
+
+.. default-domain:: mongodb
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+This tutorial shows you how to use the ``atlas deployments`` command to 
+create a local |service| deployment in Docker. In this tutorial, we 
+will deploy a single-node replica set in Docker.
+
+.. include:: /includes/fact-atlas-deployments-preview.rst
+
+.. _atlas-cli-deploy-local-reqs:
+
+Complete the Prerequisites
+--------------------------
+
+.. include:: /includes/fact-deploy-tutorial-prereqs.rst
+
+.. _atlas-cli-deploy-docker-setup:
+
+Create a Local Atlas Deployment in Docker
+-----------------------------------------
+
+Use the ``atlas deployments`` command to create a local |service|
+deployment in Docker.
+      
+.. procedure::
+   :style: normal
+
+   .. step:: Install and start Docker.
+
+      To learn more, see the `Docker documentation <https://docs.docker.com/desktop/install/mac-install/>`__.
+
+   .. step:: Pull down the latest ``mongodb/atlas`` Docker image.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         docker pull mongodb/atlas:latest
+
+   .. step:: Run the Docker image in bash mode.
+
+      To learn more, see :ref:`atlas-cli-docker`.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         docker run -p 27777:27017 --privileged -it mongodb/atlas bash
+
+   .. step:: Create a local |service| deployment.
+
+      The following command should return a connection string.
+
+      **Example:**
+
+      .. code-block::
+
+         atlas deployments setup --bindIpAll --username root --password root --type local --force
+
+   .. step:: Connect to the local |service| deployment.
+
+      To connect to the local |service| deployment from the host (not 
+      container), copy and paste the following command, and replace 
+      the ``{connection_string}`` variable with your connection string.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         mongosh {connection_string} --username root --password root
+
+
+Create a Local Atlas Deployment in Docker Compose
+-------------------------------------------------
+
+Use the ``atlas deployments`` command to create a local |service|
+deployment in Docker Compose.
+      
+.. procedure::
+   :style: normal
+
+   .. step:: Install Docker Compose.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         brew install docker-compose
+
+   .. step:: Create a docker-compose.yaml file.
+
+      **Example:**
+
+      .. code-block:: sh
+         
+         services:
+           mongo:
+             image: mongodb/atlas
+             privileged: true
+             command: |
+               /bin/bash -c "atlas deployments setup --type local --port 27778 --bindIpAll --username root --password root --force && tail -f /dev/null"
+             volumes:
+               - /var/run/docker.sock:/var/run/docker.sock
+             ports:
+               - 27778:27778
+
+   .. step:: Run Docker Compose.
+
+      The following command should return a connection string.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         docker-compose up
+    
+   .. step:: Connect to the local |service| deployment.
+
+      To connect to the local |service| deployment from the host (not 
+      container), copy and paste the following command, and replace 
+      the ``{connection_string}`` variable with your connection string.
+
+      **Example:**
+
+      .. code-block:: sh
+
+         mongosh {connection_string} --username root --password root
+
+Supported Actions
+-----------------
+
+To learn all of the actions that ``atlas deployments`` supports, see
+:ref:`atlas-deployments`.

--- a/source/atlas-cli-local-cloud.txt
+++ b/source/atlas-cli-local-cloud.txt
@@ -6,6 +6,10 @@ Manage Local and Cloud Deployments from the {+atlas-cli+}
 
 .. default-domain:: mongodb
 
+.. facet::
+   :name: genre
+   :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -89,6 +93,10 @@ deployments`` commands:
        deployment. This tutorial deploys a single-node replica set on
        your local computer.
 
+   * - :ref:`atlas-cli-deploy-docker`
+     - Use the ``atlas deployments`` command to create a local |service|
+       deployment in Docker.
+
    * - :ref:`atlas-cli-deploy-fts`
      - Use the ``atlas deployments search indexes create`` command to 
        manage |fts| indexes and work with {+avs+} locally and in the 
@@ -98,5 +106,6 @@ deployments`` commands:
    :titlesonly:
 
    Create a Local Deployment </atlas-cli-deploy-local>
+   Deploy in Docker </atlas-cli-deploy-docker>
    Use Atlas Search </atlas-cli-deploy-fts>
    


### PR DESCRIPTION
@sarahsimpers and @boooczek, I added the steps for local Atlas deployments in Docker and Docker Compose.

[STAGE: Tutorials Landing Page](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-34859/atlas-cli-local-cloud/)

[STAGE: Docker Tutorial](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-34859/atlas-cli-deploy-docker/)

[JIRA](https://jira.mongodb.org/browse/DOCSP-34859)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6581a08c7a5cb5fef59af9bd)