### PR TITLE
DOCSP-36053 Add a warning to docker compose mode on experimental status

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -135,5 +135,5 @@ value = """\
 targets = ["atlas-cli-deploy-docker.txt"]
 variant = "warning"
 value = """\
-    Local Atlas Deployment with Docker Compose is available as an experimental feature. The feature and the corresponding documentation might change at any time during the experiment.\
+    Creating Local Atlas Deployments with Docker Compose is available as an experimental feature. The feature and the corresponding documentation might change at any time during the experiment.\
     """

--- a/snooty.toml
+++ b/snooty.toml
@@ -130,3 +130,10 @@ value = """\
     new set of CLI commands for our new Data Lake functionality, we \
     will reach out to you to prevent any interruption of service.\
     """
+
+[[banners]]
+targets = ["atlas-cli-deploy-docker.txt"]
+variant = "warning"
+value = """\
+    Local Atlas Deployment with Docker Compose is available as an experimental feature. The feature and the corresponding documentation might change at any time during the experiment.\
+    """

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -129,7 +129,7 @@ deployment with `Docker Compose <https://docs.docker.com/compose/>`__.
                 ports:
                   - 27778:27778
 
-      #. Replace the password in the command on line 6 with your
+      #. Replace the ``{your-password}`` variable in the example with your
          password and save the file.
 
       To learn more about the available options, see 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -110,23 +110,27 @@ deployment with `Docker Compose <https://docs.docker.com/compose/>`__.
 
    .. step:: Create a ``docker-compose.yaml`` file.
 
-      Create the ``docker-compose.yaml`` file in the same directory 
-      that you run Docker Compose from.
+      a. Create the ``docker-compose.yaml`` file in the same directory 
+         that you run Docker Compose from.
 
-      **Example:**
+         **Example:**
 
-      .. code-block:: sh
+         .. code-block:: sh
+            :linenos: 
          
-         services:
-           mongo:
-             image: mongodb/atlas
-             privileged: true
-             command: |
-               /bin/bash -c "atlas deployments setup --type local --port 27778 --bindIpAll --username root --password root --force && tail -f /dev/null"
-             volumes:
-               - /var/run/docker.sock:/var/run/docker.sock
-             ports:
-               - 27778:27778
+            services:
+              mongo:
+                image: mongodb/atlas
+                privileged: true
+                command: |
+                  /bin/bash -c "atlas deployments setup --type local --port 27778 --bindIpAll --username root --password {your-password} --force && tail -f /dev/null"
+                volumes:
+                  - /var/run/docker.sock:/var/run/docker.sock
+                ports:
+                  - 27778:27778
+
+      #. Replace the password in the command on line 6 with your
+         password and save the file.
 
       To learn more about the available options, see 
       :ref:`atlas-deployments-setup`.


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCSP-36053)
- [Stage](https://preview-mongodbkanchanamongodb.gatsbyjs.io/atlas-cli/DOCSP-36053/atlas-cli-deploy-docker/#create-a-local-atlas-deployment-with-docker-compose)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b9530e6b2f17c95af5acc4)