### PR TITLE
(DOCSP-37173): Add documentation around HTTP Proxy support

### DIFF
--- a/source/atlas-cli-env-variables.txt
+++ b/source/atlas-cli-env-variables.txt
@@ -114,3 +114,52 @@ The {+atlas-cli+} supports the following environment variables:
 
        You can also enable or disable telemetry with ``DO_NOT_TRACK``,
        but you don't need to specify both.
+
+   * - ``HTTP_PROXY``
+     - The absolute |url| or the hostname and port in the 
+       ``hostname[:port]`` format. 
+
+       .. example:: 
+
+          The following example shows how to set up the environment 
+          variable if your proxy configuration doesn't require 
+          authentication.
+
+          .. code-block:: sh 
+             :copyable: false 
+
+             HTTP_PROXY=<my.proxy.address>
+
+          The following example shows how to set up the environment 
+          variable if your proxy configuration requires authentication.
+
+          .. code-block:: sh 
+             :copyable: false 
+
+             HTTP_PROXY=<username>:<password>@<my.proxy.address>
+
+          The following example shows how to set up the environment 
+          variable if the scheme is ``socks5``.
+
+          .. code-block:: sh 
+             :copyable: false 
+
+             HTTP_PROXY=socks5://<my.proxy.address>
+
+   * - ``HTTPS_PROXY``
+     - The absolute |url|. If ``HTTP_PROXY`` is also set, this takes 
+       precedence over ``HTTP_PROXY`` for all requests.
+
+       .. example:: 
+
+          The following example shows how to set up the environment 
+          variable.
+
+          .. code-block:: sh 
+             :copyable: false 
+
+             HTTPS_PROXY=https://<my.proxy.address>
+
+   * - ``NO_PROXY``
+     - Indicates no proxy for the |url| because proxy isn't configured 
+       for the |url|.

--- a/source/atlas-cli-save-connection-settings.txt
+++ b/source/atlas-cli-save-connection-settings.txt
@@ -103,6 +103,21 @@ Complete the Prerequisites
 - Add your host's IP address to the :ref:`IP access list <access-list>`.
 - If you select ``atlas config init`` as your connection method, you must 
   :ref:`Configure API keys <atlas-admin-api-access>`.
+- If your {+atlas-cli+} installation is behind a 
+  firewall and you want to use a proxy |url|, 
+  set up the ``HTTP_PROXY`` or ``HTTPS_PROXY`` :ref:`environment 
+  variable <atlas-cli-env-vars>`. 
+  
+  .. important:: 
+   
+     {+atlas-cli+} supports 
+     ``http``, ``https``, and ``socks5`` schemes. You must specify 
+     ``cloud.mongodb.com/`` as the main target URL 
+     in the proxy service's access list. You must also specify the 
+     username and password if your proxy configuration enables authentication. 
+
+     To learn more, see `Proxy server 
+     <https://en.wikipedia.org/wiki/Proxy_server>`__.
 
 Follow These Steps
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Documents HTTP Proxy support as we did for Mongo CLI in https://github.com/10gen/docs-mongocli/pull/665/
Question for @gssbzn, do we want to add examples for the ``NO_PROXY`` environmental variable as well?

<!-- Add a description of your PR here (optional) -->

- [DOCSP-37173](https://jira.mongodb.org/browse/DOCSP-37173)
- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65de2ad37111165982ce7fea)

Staging:
- [Environmental Variables](https://preview-mongodbdavidhou17.gatsbyjs.io/atlas-cli/DOCSP-37173/atlas-cli-env-variables/)
- [Save Connection Settings](https://preview-mongodbdavidhou17.gatsbyjs.io/atlas-cli/DOCSP-37173/atlas-cli-save-connection-settings/)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [x] Resolve any new warnings or errors in the build.
- [x] Proofread for spelling and grammatical errors.
- [x] Check staging for rendering issues.
- [x] Confirm links are working.

