### PR TITLE
(DOCSP-37597) Adds note to the migration page for people redirected from mongocli atlas commands

### DIFF
--- a/source/migrate-to-atlas-cli.txt
+++ b/source/migrate-to-atlas-cli.txt
@@ -6,11 +6,22 @@ Migrate to the {+atlas-cli+}
 
 .. default-domain:: mongodb
 
+.. facet::
+   :name: genre
+   :values: tutorial
+
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+.. note::
+
+   ``mongocli atlas`` commands for MongoCLI are now deprecated. Follow
+   the steps on this page to migrate to the {+atlas-cli+} and run
+   :doc:`{+atlas-cli+} commands </command/atlas>` instead of
+   ``mongocli atlas`` commands.
 
 If you have already configured {+mcli+}, you can migrate your settings to the
 {+atlas-cli+} easily. Migrating to the {+atlas-cli+} preserves existing {+mcli+}


### PR DESCRIPTION
There is a MongoCLI docs PR in progress to redirect all mongocli atlas docs pages to this Migration page. We should add a note to orient anyone who is redirected on why they are on this page and what to do now.

- [DOCSP](https://jira.mongodb.org/browse/DOCSP-37597)
- [STAGING](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37597/migrate-to-atlas-cli/)
- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ef31276fc5f048506bf17e)

### Self-Review Checklist

- [x] Check that the submodule pulled in the right changes (if applicable).
- [x] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [x] Resolve any new warnings or errors in the build.
- [x] Proofread for spelling and grammatical errors.
- [x] Check staging for rendering issues.
- [x] Confirm links are working.

