### PR TITLE
(DOCSP-37881): Clarified where to find the RHEL instructions for prereqs

### DIFF
--- a/source/includes/fact-deploy-tutorial-prereqs.rst
+++ b/source/includes/fact-deploy-tutorial-prereqs.rst
@@ -7,41 +7,54 @@ Before you begin, complete the following prerequisites:
 
 - Install the :ref:`{+atlas-cli+} <install-atlas-cli>`.
 
-  **Example:**
+  **Example (MacOS):**
 
   .. code-block:: sh
 
      brew install mongodb-atlas-cli
 
+  To learn about the {+atlas-cli+} install instructions for other 
+  operating systems, see :ref:`install-atlas-cli`.
+
 - Install :mongosh:`mongosh </install>` version 2.0 or later.
 
-  **Example:**
+  **Example (MacOS):**
 
   .. code-block:: sh
 
      brew install mongosh
 
+  To learn about the {+mongosh+} install instructions for other 
+  operating systems, see :mongosh:`Install mongosh </install>`.
+
 - (Optional) Install :compass:`Compass </install>` version 1.39.4 or 
   later.
 
-  **Example:**
+  **Example (MacOS):**
 
   .. code-block:: sh
 
      brew install mongodb-compass
 
+  To learn about the Compass install instructions for other operating 
+  systems, see :compass:`Download and Install Compass </install>`.
+
 - Install :dbtools:`MongoDB Database Tools 	
   </installation/installation/>`.	
 
-  **Example:**	
+  **Example (MacOS):**	
 
   .. code-block:: sh	
 
      brew tap mongodb/brew && brew install mongodb-database-tools
 
+  To learn about the MongoDB Database Tools install instructions for 
+  other operating systems, see :dbtools:`Installing the Database Tools 
+  </installation/installation/>`.
+
 - Install `Podman <https://podman.io/>`__ version 4.4 and later.
 
-  **Example:**
+  **Example (MacOS):**
 
   .. code-block:: sh
 


### PR DESCRIPTION
@blva and @sarahsimpers, I tried to clarify that the examples apply to MacOS and added extra links to the instructions for other operating systems.

- [DOCSP-37881](https://jira.mongodb.org/browse/DOCSP-37881)
- [STAGING](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-37881/atlas-cli-deploy-local/)

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66031e466fc5f048502a494c)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

