### PR TITLE
(DOCSP-38423): Added missing Docker compose line.

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -256,6 +256,7 @@ of Docker Compose.
                   - data-cni:/etc/cni
                   - data-containers:/var/lib/containers
                   - ./entrypoint.sh:/entrypoint.sh
+                entrypoint: ["/entrypoint.sh"]
                 ports:
                   - 27017:27017
                 environment:


### PR DESCRIPTION
I added the missing Docker Compose line to the following page.

- [DOCSP-38423](https://jira.mongodb.org/browse/DOCSP-38423)
- [STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/atlas-cli/docsworker-xlarge/DOCSP-38423/atlas-cli-deploy-docker/#update-your-docker-compose.yaml-file.)

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6615360b3a5920a2917be3f7)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

