### PR TITLE
(DOCSP-37380) Updates all remaining config file pages to template

### DIFF
--- a/source/includes/steps-config-file-template-action-2.rst
+++ b/source/includes/steps-config-file-template-action-2.rst
@@ -3,7 +3,7 @@ Follow these steps to |action 2| with a configuration file:
 .. procedure::
    :style: normal
 
-   .. step:: Copy the sample request for |openapi-link|.
+   .. step:: Copy the sample request for |openapi-link 2|.
 
       a. Navigate to the |openapi-link 2|
          section of the |service| Admin API specification.

--- a/source/includes/steps-config-file-template-action-2.rst
+++ b/source/includes/steps-config-file-template-action-2.rst
@@ -1,0 +1,24 @@
+Follow these steps to |action 2| with a configuration file:
+
+.. procedure::
+   :style: normal
+
+   .. step:: Copy the sample request for |openapi-link 2|.
+
+      a. Navigate to the |openapi-link 2|
+         section of the |service| Admin API specification.
+      b. Under :guilabel:`Request samples` on the right side, click
+         :guilabel:`Expand all`.
+      c. Click :guilabel:`Copy` to copy the sample request.
+
+   .. step:: Create the configuration file.
+    
+      a. Paste the sample request into a text editor and change
+         the values to reflect your desired configuration.
+      b. Save the file with a ``.json`` extension.
+
+   .. step:: Run the |atlas-cli command 2| command with 
+      the ``--file`` option.
+
+      Specify the path to the file you saved with the ``--file`` flag.
+

--- a/source/includes/steps-config-file-template-action-3.rst
+++ b/source/includes/steps-config-file-template-action-3.rst
@@ -1,11 +1,11 @@
-Follow these steps to |action 2| with a configuration file:
+Follow these steps to |action 3| with a configuration file:
 
 .. procedure::
    :style: normal
 
-   .. step:: Copy the sample request for |openapi-link|.
+   .. step:: Copy the sample request for |openapi-link 3|.
 
-      a. Navigate to the |openapi-link 2|
+      a. Navigate to the |openapi-link 3|
          section of the |service| Admin API specification.
       b. Under :guilabel:`Request samples` on the right side, click
          :guilabel:`Expand all`.
@@ -17,7 +17,7 @@ Follow these steps to |action 2| with a configuration file:
          the values to reflect your desired configuration.
       b. Save the file with a ``.json`` extension.
 
-   .. step:: Run the |atlas-cli command 2| command with 
+   .. step:: Run the |atlas-cli command 3| command with 
       the ``--file`` option.
 
       Specify the path to the file you saved with the ``--file`` flag.

--- a/source/reference/json/alert-config-file.txt
+++ b/source/reference/json/alert-config-file.txt
@@ -10,104 +10,49 @@ Alert Configuration File
    :depth: 1
    :class: singlecol
 
-You can use a configuration file to specify the
-settings for :ref:`creating <atlas-alerts-settings-create>`
-or :ref:`updating <atlas-alerts-settings-update>` an alert
-configuration through the {+atlas-cli+}. The {+atlas-cli+}
-accepts ``.json`` configuration files.
+
+.. This page differs from the main template because it documents
+.. multiple commands For a one-command
+.. template, use the template on cloud-backup-schedule-config-file.txt
+
+.. |atlas-cli command| replace:: :ref:`atlas-alerts-settings-create`
+.. |configuration-file-name| replace:: alert configuration  
+.. |openapi-link| replace:: :oas-atlas-op:`Create One Alert Configuration in One Project </Alert-Configurations/operation/createAlertConfiguration>`
+.. |action| replace:: create an alert configuration
+
+.. |atlas-cli command 2| replace:: :ref:`atlas-alerts-settings-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Update One Alert Configuration for One Project </Alert-Configurations/operation/updateAlertConfiguration>`
+.. |action 2| replace:: update an alert configuration
+
+You can use a |configuration-file-name| file to specify the
+settings required when you |action| or |action 2|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _alert-config-settings:
 
-Alert Configuration Settings
-----------------------------
+Available Settings
+------------------
 
-Depending on the type of alert configuration, you can specify the 
-following settings to create or update an alert configuration 
-in a configuration file:
+When you |action| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link| under :guilabel:`Request Body Schema`.
 
-.. list-table::
-   :widths: 20 10 70
-   :header-rows: 1
-
-   * - Field
-     - Type
-     - Description
-
-   * - ``enabled``
-     - boolean
-     - Flag that indicates whether someone enabled this
-       alert configuration for the specified project.
-
-   * - ``eventTypeName``
-     - string
-     - Required. Event type that triggers an alert.
-
-   * - ``matchers``
-     - array of objects
-     - Rules to apply when matching an object against this alert
-       configuration. You can use this field only if the ``eventTypeName``
-       specifies an event for a host, replica set, or sharded cluster.
-
-   * - ``metricThreshold``
-     - object
-     - Threshold for the metric that, when exceeded, triggers an alert.
-       You can use this field only if the ``eventTypeName`` reflects
-       a change in measurement or metric.
-
-   * - ``notifications``
-     - array of objects
-     - List that contains the targets that |service| sends notifications.
-
-   * - ``threshold``
-     - object
-     - A limit that triggers an alert when exceeded.
-
-For detailed descriptions and a full list of available settings,
-see the request body schema in the API specification:
-
-- :oas-atlas-op:`Create One Alert Configuration in One Project </createAlertConfiguration>`
-- :oas-atlas-op:`Update One Alert Configuration for One Project </updateAlertConfiguration>`
+When you |action 2| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 2| under :guilabel:`Request Body Schema`.
 
 .. _example-alert-config-file:
 
-Example Alert Configuration File
---------------------------------
-
-To create or update an alert configuration, specify the
-fields that you want to include in the configuration file.
-For example, the following sample file enables an alert 
-configuration that notifies you when a replica set called 
-``event-replica-set`` loses its primary node:
-
-.. literalinclude:: /includes/alert-configuration-config-file.json
-
-Example Alert Configuration Commands
-------------------------------------
-
-After you create the file, run the {+atlas-cli+} 
-command to create or update the alert configuration.
+Create a Configuration File
+---------------------------
 
 Create an Alert Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To create an alert configuration, specify the ``--flag`` option 
-and the path to the file. The following example creates an 
-alert configuration by using a configuration file named 
-``alert-config.json``:
-
-.. code-block::
-
-   atlas alerts settings create --file /alert-config.json
+.. include:: /includes/steps-config-file-template.rst
 
 Update an Alert Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To update an alert configuration, specify the ID of the
-alert configuration that you want to update, the ``--flag``
-option, and the path to the file. The following example updates 
-an existing alert configuration by using a configuration file 
-named ``alert-config.json``:
-
-.. code-block::
-
-   atlas alerts settings update <alertConfigId> --file /alert-config.json
+.. include:: /includes/steps-config-file-template-action-2.rst

--- a/source/reference/json/cluster-config-file.txt
+++ b/source/reference/json/cluster-config-file.txt
@@ -11,16 +11,21 @@
    :class: singlecol
 
 
-.. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
-.. |configuration-file-name| replace:: search nodes configuration  
-.. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
-.. |action| replace:: create search nodes
-.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-search-nodes-update`
-.. |openapi-link 2| replace:: :oas-atlas-tag:`Update Search Nodes </Atlas-Search/operation/updateAtlasSearchDeployment>`
-.. |action 2| replace:: update search nodes
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-create`
+.. |configuration-file-name| replace:: cluster configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create One Cluster from One Project </Clusters/operation/createCluster>`
+.. |action| replace:: create clusters
+  
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Modify One Cluster from One Project </Clusters/operation/updateCluster>`
+.. |action 2| replace:: update clusters
+
+.. |atlas-cli command 3| replace:: :ref:`atlas-clusters-upgrade`
+.. |openapi-link 3| replace:: :oas-atlas-tag:`Upgrade One Shared-tier Cluster </Clusters/operation/upgradeSharedCluster>`
+.. |action 3| replace:: upgrade clusters
 
 You can use a |configuration-file-name| file to specify the
-settings required when you |action| or |action 2|
+settings required when you |action|, |action 2|, or |action 3|
 using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
 |configuration-file-name| files.
 
@@ -38,48 +43,37 @@ When you |action 2| using a configuration file, you
 can specify any settings that are listed in 
 |openapi-link 2| under :guilabel:`Request Body Schema`.
 
+When you |action 3| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 3| under :guilabel:`Request Body Schema`.
+
 .. _example-cluster-config-file:
-.. _multi-cloud-example-cluster-config-file:
-.. _geosharded-example-cluster-config-file:
 
 Create a Configuration File
 ---------------------------
 
-Create a Search Node
-~~~~~~~~~~~~~~~~~~~~
+Create a Cluster
+~~~~~~~~~~~~~~~~
 
 .. include:: /includes/steps-config-file-template.rst
 
-Update a Search Node
-~~~~~~~~~~~~~~~~~~~~
+Update a Cluster
+~~~~~~~~~~~~~~~~
 
-.. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
-.. |configuration-file-name| replace:: search nodes configuration  
-.. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
-.. |action| replace:: create search nodes
+.. include:: /includes/steps-config-file-template-action-2.rst
 
-.. include:: /includes/steps-config-file-template.rst
+Upgrade a Cluster
+~~~~~~~~~~~~~~~~~
 
+.. include:: /includes/steps-config-file-template-action-3.rst
 
+Example Configuration Files
+---------------------------
 
-
-
-
-
-
-Example Cluster Configuration File
-----------------------------------
-
-To create a {+cluster+} using a single cloud provider, specify the same
-service provider for your ``regionConfigs`` objects as shown in the
-following example file:
-
-.. literalinclude:: /includes/json-cluster-config-file.json
-
-
+.. _multi-cloud-example-cluster-config-file:
 
 Example Multi-Cloud Cluster Configuration File
-----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To create a multi-cloud {+cluster+}, specify more than one
 service provider for your ``regionConfigs`` objects as shown in the
@@ -87,10 +81,10 @@ following example file:
 
 .. literalinclude:: /includes/json-cluster-config-file-multi.json
 
-
+.. _geosharded-example-cluster-config-file:
 
 Example Geosharded Cluster Configuration File
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To create a :ref:`geosharded <global-clusters>` {+cluster+}, specify zones for your ``replicationSpecs`` objects as shown in the following example file:
 

--- a/source/reference/json/cluster-config-file.txt
+++ b/source/reference/json/cluster-config-file.txt
@@ -10,200 +10,62 @@
    :depth: 1
    :class: singlecol
 
-You can use a {+cluster+} configuration file to specify the settings
-required when you create or update a {+cluster+} using the 
-{+atlas-cli+}. The {+atlas-cli+} accepts ``.json``
-{+cluster+} configuration files.
 
-Use the following resources to:
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
+.. |configuration-file-name| replace:: search nodes configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
+.. |action| replace:: create search nodes
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-search-nodes-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Update Search Nodes </Atlas-Search/operation/updateAtlasSearchDeployment>`
+.. |action 2| replace:: update search nodes
 
-- Learn the :ref:`required settings <required-cluster-settings>` you
-  can specify in the {+cluster+} configuration file.
-- View and copy :ref:`sample configuration files
-  <example-cluster-config-file>`.
+You can use a |configuration-file-name| file to specify the
+settings required when you |action| or |action 2|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _required-cluster-settings:
-
-Required {+Cluster+} Settings
------------------------------
-
-|service| requires the following settings to create a {+cluster+} with
-the {+atlas-cli+}. You must specify these {+cluster+} settings either
-in the configuration file or as flags in the command:
-
-.. list-table:: 
-   :header-rows: 1 
-   :widths: 20 10 70 
-
-   * - Field 
-     - Type 
-     - Description 
-
-   * - ``clusterType``
-     - string
-     - Human-readable label that indicates the type of {+cluster+} to
-       create. Values include: ``REPLICASET``, ``SHARDED``, or
-       ``GEOSHARDED``.
-
-   * - ``name``
-     - string
-     - Human-readable label that identifies the {+cluster+}.
-
-   * - ``replicationSpecs``
-     - array
-     - List that contains the configuration settings for your 
-       {+cluster+} regions and the hardware provisioned in them.
-
-   * - ``replicationSpecs.``
-       ``regionConfigs``
-     - array
-     - List that contains the hardware specifications for the nodes set
-       within the region that you specify. Each ``regionConfigs``
-       object describes the region's priority in elections and the
-       number and type of MongoDB nodes that |service| deploys to the
-       region.
-       
-       Each ``regionConfigs`` object must have either an
-       ``analyticsSpecs`` object, ``electableSpecs`` object, or
-       ``readOnlySpecs`` object.
-
-       - Shared {+clusters+} require only ``electableSpecs``.
-       - Dedicated {+clusters+} can specify any of these
-         specifications, but must have at least one ``electableSpecs``
-         object within a ``replicationSpec``.
-       - Every hardware specification must use the same
-         ``instanceSize``.
-
-   * - ``replicationSpecs.``
-       ``regionConfigs.electableSpecs``
-     - object
-     - Hardware specifications for electable nodes in the region.
-       Electable nodes can become the 
-       :manual:`primary </core/replica-set-members/#std-label-replica-set-primary-member>` and can enable
-       local reads.
-
-   * - ``replicationSpecs.``
-       ``regionConfigs.``
-       ``electableSpecs.instanceSize``
-     - string
-     - Hardware specification for the instance sizes in this region. To
-       learn more, see :ref:`create-cluster-instance`.
-
-   * - ``replicationSpecs``
-       ``.regionConfigs.``
-       ``electableSpecs.nodeCount``
-     - number
-     - Number of electable nodes for |service| to deploy to the region.
-       Electable nodes can become the 
-       :manual:`primary </core/replica-set-members/#std-label-replica-set-primary-member>` and can enable
-       local reads.
-
-       The combined electableSpecs.nodeCount across all 
-       replicationSpecs[n].regionConfigs[m] objects must total 3, 5, or
-       7.
-
-   * - ``replicationSpecs.``
-       ``regionConfigs.priority``
-     - Integer
-     - Precedence that is given to this region when a primary election
-       occurs.
-
-       If your region has set ``electableSpecs.nodeCount`` to ``1`` or
-       higher, it must have a priority of exactly one (1) less than
-       another region in the ``replicationSpecs[n].regionConfigs[m]``
-       array. The highest-priority region must have a priority of
-       ``7``. The lowest possible priority is ``1``.
-
-       The priority ``7`` region identifies the preferred region of the
-       {+cluster+}. |service| places the 
-       :manual:`primary </core/replica-set-members/#std-label-replica-set-primary-member>` node in the
-       preferred region.
-
-   * - ``replicationSpecs.``
-       ``regionConfigs.providerName``
-     - string
-     - Human-readable label that identifies your cloud service
-       provider. Values include: ``AWS``, ``AZURE``, or ``GCP``.
-
-       To create a multi-cloud {+cluster+}, specify more than one
-       service provider for your ``regionConfigs`` objects. To
-       learn more, see the :ref:`multi-cloud example configuration file
-       <multi-cloud-example-cluster-config-file>`
-
-   * - ``replicationSpecs.``
-       ``regionConfigs.regionName``
-     - string
-     - Human-readable label that indicates the physical location of
-       your {+cluster+} nodes. The region you choose can affect network
-       latency for clients accessing your databases.
-     
-       For a complete list of region name values, refer to the the
-       cloud provider reference pages:
-   
-       - :atlas:`AWS </reference/amazon-aws/#amazon-aws>>`
-       - :atlas:`GCP </reference/google-gcp/#google-gcp>`
-       - :atlas:`Azure </reference/microsoft-azure/#microsoft-azure>`
-
 .. _optional-cluster-settings:
 
-Optional and Conditional {+Cluster+} Settings
----------------------------------------------
+Available Settings
+------------------
 
-Your {+cluster+} configuration file may contain additional optional or
-conditional {+cluster+} settings. If you selected a ``clusterType`` of ``GEOSHARDED``, you must specify the following {+cluster+} settings either
-in the configuration file or as flags in the command:
+When you |action| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link| under :guilabel:`Request Body Schema`.
 
-.. list-table:: 
-   :header-rows: 1 
-   :widths: 20 10 70 
-
-   * - Field 
-     - Type 
-     - Description 
-
-   * - ``replicationSpecs.``
-       ``numShards``
-     - string
-     - Positive integer that specifies the number of shards to deploy
-       in each specified zone. Provide this value if you set a
-       ``clusterType`` of ``SHARDED`` or ``GEOSHARDED``. Omit this
-       value if you selected a ``clusterType`` of ``REPLICASET``.
-
-       This API resource accepts ``1`` through ``50``, inclusive. This
-       parameter defaults to ``1``.
-
-       If you specify a ``numShards`` value of ``1`` and a
-       ``clusterType`` of ``SHARDED``, |service| deploys a single-shard
-       :manual:`sharded cluster </reference/glossary/#std-term-sharded-cluster>`.
-
-       Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
-
-   * - ``replicationSpecs.``
-       ``zoneName``
-     - string
-     - Name for the zone in a :ref:`Global Cluster <global-clusters>`. 
-       Provide this value if you set ``clusterType`` to ``GEOSHARDED``.
-
-   * - ``tags``
-     - array
-     - List that contains key-value pairs between 1 to 255 characters in length for 
-       :ref:`tagging and categorizing the cluster <configure-resource-tags>`. 
-
-   * - ``tags.key``
-     - string
-     - Constant that defines the set of the tag. For example, ``environment`` in the
-       ``environment : production`` tag. 
-
-   * - ``tags.value``
-     - string
-     - Variable that belongs to the set of the tag. For example, ``production`` in the
-       ``environment : production`` tag.
-
-For a full list of available
-settings, see the API documentation for 
-:oas-atlas-op:`Create One Multi-Cloud Cluster from One Project </createCluster>`.
+When you |action 2| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 2| under :guilabel:`Request Body Schema`.
 
 .. _example-cluster-config-file:
+.. _multi-cloud-example-cluster-config-file:
+.. _geosharded-example-cluster-config-file:
+
+Create a Configuration File
+---------------------------
+
+Create a Search Node
+~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/steps-config-file-template.rst
+
+Update a Search Node
+~~~~~~~~~~~~~~~~~~~~
+
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
+.. |configuration-file-name| replace:: search nodes configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
+.. |action| replace:: create search nodes
+
+.. include:: /includes/steps-config-file-template.rst
+
+
+
+
+
+
+
 
 Example Cluster Configuration File
 ----------------------------------
@@ -214,7 +76,7 @@ following example file:
 
 .. literalinclude:: /includes/json-cluster-config-file.json
 
-.. _multi-cloud-example-cluster-config-file:
+
 
 Example Multi-Cloud Cluster Configuration File
 ----------------------------------------------
@@ -225,7 +87,7 @@ following example file:
 
 .. literalinclude:: /includes/json-cluster-config-file-multi.json
 
-.. _geosharded-example-cluster-config-file:
+
 
 Example Geosharded Cluster Configuration File
 ---------------------------------------------

--- a/source/reference/json/cluster-config-file.txt
+++ b/source/reference/json/cluster-config-file.txt
@@ -15,7 +15,7 @@
 .. |configuration-file-name| replace:: cluster configuration  
 .. |openapi-link| replace:: :oas-atlas-tag:`Create One Cluster from One Project </Clusters/operation/createCluster>`
 .. |action| replace:: create clusters
-  
+
 .. |atlas-cli command 2| replace:: :ref:`atlas-clusters-update`
 .. |openapi-link 2| replace:: :oas-atlas-tag:`Modify One Cluster from One Project </Clusters/operation/updateCluster>`
 .. |action 2| replace:: update clusters
@@ -48,6 +48,8 @@ can specify any settings that are listed in
 |openapi-link 3| under :guilabel:`Request Body Schema`.
 
 .. _example-cluster-config-file:
+.. _multi-cloud-example-cluster-config-file:
+.. _geosharded-example-cluster-config-file:
 
 Create a Configuration File
 ---------------------------
@@ -66,26 +68,3 @@ Upgrade a Cluster
 ~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/steps-config-file-template-action-3.rst
-
-Example Configuration Files
----------------------------
-
-.. _multi-cloud-example-cluster-config-file:
-
-Example Multi-Cloud Cluster Configuration File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To create a multi-cloud {+cluster+}, specify more than one
-service provider for your ``regionConfigs`` objects as shown in the
-following example file:
-
-.. literalinclude:: /includes/json-cluster-config-file-multi.json
-
-.. _geosharded-example-cluster-config-file:
-
-Example Geosharded Cluster Configuration File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To create a :ref:`geosharded <global-clusters>` {+cluster+}, specify zones for your ``replicationSpecs`` objects as shown in the following example file:
-
-.. literalinclude:: /includes/geosharded-cluster-config-file.json

--- a/source/reference/json/data-federation-config-file.txt
+++ b/source/reference/json/data-federation-config-file.txt
@@ -10,94 +10,35 @@
    :depth: 1
    :class: singlecol
 
-You can use an {+adf+} configuration file to specify the required 
-settings for :ref:`creating a federated database
-<atlas-dataFederation-create>` using the {+atlas-cli+}. The 
-{+atlas-cli+} accepts ``.json`` {+df+} configuration files.
+.. facet::
+   :name: genre
+   :values: tutorial
 
-Use the following resources to:
+.. To create a configuration file doc, copy this template, change
+.. the replacements below, and update the H1 title and refs.
 
-- Learn the :ref:`required settings <required-fdi-settings>` you
-  can specify in the {+cluster+} configuration file.
-- View and copy :ref:`sample configuration files
-  <example-fdi-config-file>`.
+.. |atlas-cli command| replace:: :ref:`atlas-dataFederation-create`
+.. |configuration-file-name| replace:: data federation configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create One Federated Database Instance in One Project </Data-Federation/operation/createFederatedDatabase>`
+.. |action| replace:: create a federated database instance
+
+You can use a |configuration-file-name| file to specify the
+settings required when you |action|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _required-fdi-settings:
 
-Required {+adf+} Settings
----------------------------------------
+Available Settings
+------------------
 
-|service| requires the following settings to create a {+fdi+} with
-the {+atlas-cli+}. You must specify these {+fdi+} settings either in the configuration 
-file or as flags in the command: 
-
-.. list-table:: 
-   :header-rows: 1 
-   :widths: 20 10 70 
-
-   * - Field 
-     - Type 
-     - Description 
-
-   * - ``cloudProviderConfig.``
-       ``aws``
-     - object
-     - Cloud provider linked to this {+fdi+}.
-
-   * - ``cloudProviderConfig.``
-       ``aws.``
-       ``roleId``
-     - string
-     - Unique identifier of the role that the {+fdi+} can use to access the data stores.       
-       Required if specifying ``cloudProviderConfig``.
-
-   * - ``cloudProviderConfig.``
-       ``aws.``
-       ``testS3Bucket``
-     - string
-     - Name of the |s3| data bucket that the provided role ID is authorized to access. Required if specifying ``cloudProviderConfig``.
-
-   * - ``dataProcessRegion.``
-       ``cloudProvider``
-     - string
-     - Name of the cloud service that hosts the {+fdi+}\'s data stores. For example, ``AWS``, ``GCP``, ``AZURE``, ``TENANT``, or ``SERVERLESS``.
-
-   * - ``dataProcessRegion.``
-       ``region``
-     - string
-     - Name of the region to which the {+fdi+} routes client connections. For the full
-       list of available regions, see :ref:`Cloud Providers and Regions <create-cluster-cloud-provider-region>`.
-
-   * - ``name``
-     - string
-     - Human-readable label that identifies the {+fdi+}.
-
-   * - ``storage.``
-       ``stores.``
-       ``name``
-     - string
-     - Human-readable label that identifies the data store. 
-       The ``databases.[n].collections.[n].dataSources.[n].storeName`` field references 
-       this value as part of the mapping configuration. To use |service| as a data store, 
-       the {+fdi+} requires a serverless instance or an ``M10`` or higher {+cluster+}.
-
-   * - ``storage.``
-       ``stores.``
-       ``provider``
-     - string
-     - The :ref:`type of data store <config-adf>`. For example, ``atlas``, ``http``, ``online_archive``, ``s3``, or ``DataLakeAzureBlobStore``.
-
-
-For a full list of available settings, see
-the request body schema in the API specification:
-:oas-atlas-op:`Create One Federated Database Instance in One Project </createFederatedDatabase>`.
+When you |action| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link| under :guilabel:`Request Body Schema`.
 
 .. _example-fdi-config-file:
 
-Example {+adf+} Configuration File
-------------------------------------------------
+Create a Configuration File
+---------------------------
 
-To create a {+fdi+}, specify the
-fields you want to update as shown in the following example file:
-
-.. literalinclude:: /includes/data-federation-instance-config-file.json
+.. include:: /includes/steps-config-file-template.rst

--- a/source/reference/json/file-options-online-archive.txt
+++ b/source/reference/json/file-options-online-archive.txt
@@ -10,105 +10,48 @@ Online Archive Configuration File
    :depth: 1
    :class: singlecol
 
-You can use a configuration file to specify the required  
-settings for creating and updating an online archive using the 
-{+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` online archive 
-configuration files.
+.. This page differs from the main template because it documents
+.. multiple commands For a one-command
+.. template, use the template on cloud-backup-schedule-config-file.txt
 
-Use the following resources to:
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-onlineArchive-create`
+.. |configuration-file-name| replace:: online archive configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create One Online Archive </Online-Archive/operation/createOnlineArchive>`
+.. |action| replace:: create online archives
 
-- Learn the :ref:`required settings <required-oa-settings>` you 
-  can specify in the online archive 
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-onlineArchive-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Update One Online Archive </Online-Archive/operation/updateOnlineArchive>`
+.. |action 2| replace:: update online archives
 
-- View and copy :ref:`sample configuration files <example-oa-config-file>`.
+You can use a |configuration-file-name| file to specify the
+settings required when you |action| or |action 2|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _required-oa-settings:
 
-Online Archive Settings
------------------------
+Available Settings
+------------------
 
-You can specify the following settings to create or 
-update an online archive either in the configuration 
-file or as flags in the command:
+When you |action| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link| under :guilabel:`Request Body Schema`.
 
-.. list-table:: 
-   :header-rows: 1 
-   :widths: 20 10 70 
-
-   * - Field 
-     - Type 
-     - Description 
-
-   * - ``groupId``
-     - string
-     - Unique identifier for your project. Your ``groupId`` is the same 
-       as your ``projectId``. For existing groups, your 
-       ``groupId`` and ``projectId`` remains the same. 
-       The resource and corresponding endpoints use the term groups.
-
-   * - ``archiveID``
-     - string
-     - Unique 24-hexadecimal digit string that identifies 
-       the online archive to update.
-  
-   * - ``clusterName``
-     - string
-     - Human-readable label that identifies the cluster that contains 
-       the collection for which you want to create or update one online archive.
-
-   * - ``collName``
-     - string
-     - The name of your collection.
-
-   * - ``criteria``
-     - object
-     - Rules by which MongoDB MongoDB Cloud archives data.
-
-   * - ``dbName``
-     - string
-     - Human-readable label of the database that 
-       contains the collection that contains the online archive.
-
-For detailed descriptions and a full list of available settings,
-see the request body schema in the API specification:
-
-- :oas-atlas-op:`Create One Online Archive </createOnlineArchive>`
-- :oas-atlas-op:`Update One Online Archive </updateOnlineArchive>`
+When you |action 2| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 2| under :guilabel:`Request Body Schema`.
 
 .. _example-oa-config-file:
 
-Example Online Archive Create Configuration File
-------------------------------------------------
+Create a Configuration File
+---------------------------
 
-.. literalinclude:: /includes/online-archive-create.json
+Create an Online Archive
+~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. include:: /includes/steps-config-file-template.rst
 
-Example Online Archive Update Configuration File
-------------------------------------------------
+Update an Online Archive
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. literalinclude:: /includes/online-archive-update.json
-
-Example Online Archive Create Command
--------------------------------------
-To create an online archive configuration, specify the ``--file`` option 
-and the path to the file. The following example creates an 
-online archive by using a configuration file named 
-``online-archive-create-config.json``:
-
-.. code-block::
-
-    atlas clusters onlineArchive create --file online-archive-create-config.json --output json
-
-Example Online Archive Update Command
--------------------------------------
-To update an online archive configuration, specify the ``--file`` option 
-and the path to the file. The following example updates an 
-online archive by using a configuration file named 
-``online-archive-update-config.json``:
-
-.. code-block::
-
-    atlas clusters onlineArchive update --file online-archive-update-config.json --output json
-
-
-
+.. include:: /includes/steps-config-file-template-action-2.rst

--- a/source/reference/json/file-options-online-archive.txt
+++ b/source/reference/json/file-options-online-archive.txt
@@ -14,12 +14,12 @@ Online Archive Configuration File
 .. multiple commands For a one-command
 .. template, use the template on cloud-backup-schedule-config-file.txt
 
-.. |atlas-cli command| replace:: :ref:`atlas-clusters-onlineArchive-create`
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-onlineArchives-create`
 .. |configuration-file-name| replace:: online archive configuration  
 .. |openapi-link| replace:: :oas-atlas-tag:`Create One Online Archive </Online-Archive/operation/createOnlineArchive>`
 .. |action| replace:: create online archives
 
-.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-onlineArchive-update`
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-onlineArchives-update`
 .. |openapi-link 2| replace:: :oas-atlas-tag:`Update One Online Archive </Online-Archive/operation/updateOnlineArchive>`
 .. |action 2| replace:: update online archives
 

--- a/source/reference/json/rolling-index-config-file.txt
+++ b/source/reference/json/rolling-index-config-file.txt
@@ -32,10 +32,10 @@ When you |action| using a configuration file, you
 can specify any settings that are listed in 
 |openapi-link| under :guilabel:`Request Body Schema`.
 
-.. seealso:: Title
+.. seealso:: Rolling Index File Examples
 
    - `Unique indexes <https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/e2e/atlas/data/create_2dspere_index.json>`__ 
-   - `Sparse Index <https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/e2e/atlas/data/create_sparse_index.json>`__ 
+   - `Sparse indexes <https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/e2e/atlas/data/create_sparse_index.json>`__ 
    - `Partial indexes <https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/e2e/atlas/data/create_partial_index.json>`__ 
 
 .. _example-rolling-index-config-file:

--- a/source/reference/json/search-index-config-file.txt
+++ b/source/reference/json/search-index-config-file.txt
@@ -14,14 +14,23 @@ Atlas Search Index Configuration File
    :depth: 1
    :class: singlecol
 
+.. This page differs from the main template because it documents
+.. multiple commands For a one-command
+.. template, use the template on cloud-backup-schedule-config-file.txt
+
 .. |atlas-cli command| replace:: :ref:`atlas-clusters-search-indexes-create`
 .. |configuration-file-name| replace:: search index configuration  
 .. |openapi-link| replace:: :oas-atlas-op:`Create One Atlas Search Index </createAtlasSearchIndex>`
 .. |action| replace:: create an Atlas Search index
 
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-search-indexes-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Update One Atlas Search Index </Online-Archive/operation/updateAtlasSearchIndex>`
+.. |action 2| replace:: update an Atlas Search index
+
 You can use a |configuration-file-name| file to specify the
-settings required when you |action| using the {+atlas-cli+}. The
-{+atlas-cli+} accepts ``.json`` |configuration-file-name| files.
+settings required when you |action| or |action 2|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _search-index-settings:
 
@@ -32,31 +41,21 @@ When you |action| using a configuration file, you
 can specify any settings that are listed in 
 |openapi-link| under :guilabel:`Request Body Schema`.
 
+When you |action 2| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 2| under :guilabel:`Request Body Schema`.
+
 .. _example-search-index-config-file:
 
 Create a Configuration File
 ---------------------------
 
-Follow these steps to |action| with a configuration file:
+Create an Atlas Search Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. procedure::
-   :style: normal
+.. include:: /includes/steps-config-file-template.rst
 
-   .. step:: Copy the sample request for |openapi-link|.
+Update an Atlas Search Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      a. Navigate to the |openapi-link|
-         section of the |service| Admin API specification.
-      b. Under :guilabel:`Request samples` on the right side, click
-         :guilabel:`Expand all`.
-      c. Click :guilabel:`Copy` to copy the sample request.
-
-   .. step:: Create the configuration file.
-    
-      a. Paste the copied sample request into a text editor and change
-         the values to reflect your values.
-      b. Save the file with a ``.json`` extension.
-
-   .. step:: Run the |atlas-cli command| command with 
-      the ``--file`` option.
-
-      Specify the path to the file you saved with the ``--file`` flag.
+.. include:: /includes/steps-config-file-template-action-2.rst

--- a/source/reference/json/search-nodes-config-file.txt
+++ b/source/reference/json/search-nodes-config-file.txt
@@ -10,85 +10,32 @@ Search Nodes Configuration File
    :depth: 1
    :class: singlecol
 
-To create or update :atlas:`search nodes 
-</cluster-config/multi-cloud-distribution/#std-label-configure-search-nodes>` 
-for a {+cluster+} by using the {+atlas-cli+}, you can use a ``.json`` 
-configuration file to specify the required search nodes settings.
+
+.. To create a configuration file doc, copy this template, change
+.. the replacements below, and update the H1 title and refs.
+
+.. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
+.. |configuration-file-name| replace:: search nodes configuration  
+.. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
+.. |action| replace:: create search nodes
+
+You can use a |configuration-file-name| file to specify the
+settings required when you |action|
+using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
+|configuration-file-name| files.
 
 .. _search-nodes-settings:
 
-Search Nodes Settings
----------------------
+Available Settings
+------------------
 
-You can specify the following settings in the search nodes
-configuration file. For a full list of settings and 
-descriptions, see the :oas-atlas-op:`API specification 
-</createAtlasSearchDeployment>`.
-
-.. list-table:: 
-   :header-rows: 1 
-   :widths: 20 10 70 
-
-   * - Field 
-     - Type 
-     - Description 
-
-   * - ``specs``
-     - Array of objects
-     - Settings to configure search nodes for your {+cluster+}.
-
-   * - ``specs.instanceSize``
-     - string
-     - Hardware specification for the search node instance sizes.
-       This setting uses the following format:
-
-       - ``<instance-size>_HIGHCPU_NVME``
-       - ``<instance-size>_LOWCPU_NVME``
-
-       For example, ``S20_HIGHCPU_NVME``.
-       To learn more, see :atlas:`Search Nodes Costs
-       </billing/search-node>`.
-
-   * - ``specs.nodeCount``
-     - integer
-     - Number of search nodes in the {+cluster+}.
+When you |action| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link| under :guilabel:`Request Body Schema`.
 
 .. _example-search-nodes-config-file:
 
-Example Search Nodes Configuration File
----------------------------------------
+Create a Configuration File
+---------------------------
 
-To create or update search nodes on your {+cluster+}, 
-define the search nodes settings in your |json| file 
-as shown in the following example file:
-
-.. literalinclude:: /includes/create-search-node-config-file.json
-
-Example Search Nodes Configuration Commands
--------------------------------------------
-
-After you create the file, run the {+atlas-cli+} command 
-to create or update search nodes and specify 
-the ``clusterName`` and ``file`` options. 
-
-Create Search Nodes
-~~~~~~~~~~~~~~~~~~~
-
-The following example creates search nodes for the {+cluster+} named
-``myCluster`` using a JSON configuration file named 
-``search-nodes-config.json``:
-
-.. code-block::
-
-    atlas clusters search nodes create --clusterName myCluster --file search-nodes-config.json
-
-Update Search Nodes
-~~~~~~~~~~~~~~~~~~~
-
-The following example updates search nodes for the {+cluster+} named
-``myCluster`` using a JSON configuration file named 
-``search-nodes-config.json``:
-
-.. code-block::
-
-    atlas clusters search nodes update --clusterName myCluster --file search-nodes-config.json
+.. include:: /includes/steps-config-file-template.rst

--- a/source/reference/json/search-nodes-config-file.txt
+++ b/source/reference/json/search-nodes-config-file.txt
@@ -10,17 +10,20 @@ Search Nodes Configuration File
    :depth: 1
    :class: singlecol
 
-
-.. To create a configuration file doc, copy this template, change
-.. the replacements below, and update the H1 title and refs.
+.. This page differs from the main template because it documents
+.. multiple commands For a one-command
+.. template, use the template on cloud-backup-schedule-config-file.txt
 
 .. |atlas-cli command| replace:: :ref:`atlas-clusters-search-nodes-create`
 .. |configuration-file-name| replace:: search nodes configuration  
 .. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
 .. |action| replace:: create search nodes
+.. |atlas-cli command 2| replace:: :ref:`atlas-clusters-search-nodes-update`
+.. |openapi-link 2| replace:: :oas-atlas-tag:`Update Search Nodes </Atlas-Search/operation/updateAtlasSearchDeployment>`
+.. |action 2| replace:: update search nodes
 
 You can use a |configuration-file-name| file to specify the
-settings required when you |action|
+settings required when you |action| or |action 2|
 using the {+atlas-cli+}. The {+atlas-cli+} accepts ``.json`` 
 |configuration-file-name| files.
 
@@ -33,9 +36,21 @@ When you |action| using a configuration file, you
 can specify any settings that are listed in 
 |openapi-link| under :guilabel:`Request Body Schema`.
 
+When you |action 2| using a configuration file, you
+can specify any settings that are listed in 
+|openapi-link 2| under :guilabel:`Request Body Schema`.
+
 .. _example-search-nodes-config-file:
 
 Create a Configuration File
 ---------------------------
 
+Create a Search Node
+~~~~~~~~~~~~~~~~~~~~
+
 .. include:: /includes/steps-config-file-template.rst
+
+Update a Search Node
+~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/steps-config-file-template-action-2.rst

--- a/source/reference/json/search-nodes-config-file.txt
+++ b/source/reference/json/search-nodes-config-file.txt
@@ -18,6 +18,7 @@ Search Nodes Configuration File
 .. |configuration-file-name| replace:: search nodes configuration  
 .. |openapi-link| replace:: :oas-atlas-tag:`Create Search Nodes </Atlas-Search/operation/createAtlasSearchDeployment>`
 .. |action| replace:: create search nodes
+
 .. |atlas-cli command 2| replace:: :ref:`atlas-clusters-search-nodes-update`
 .. |openapi-link 2| replace:: :oas-atlas-tag:`Update Search Nodes </Atlas-Search/operation/updateAtlasSearchDeployment>`
 .. |action 2| replace:: update search nodes


### PR DESCRIPTION
This PR updates all remaining manually-documented config file pages to the template that was agreed-upon in #278. It also adds a second and third template to handle config file pages that should document more than one command (ones that support create + update, or clusters that support create, update, or upgrade)

Use of this template already has tech review approval from #278 

- [DOCSP-37380](https://jira.mongodb.org/browse/DOCSP-37380)
- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=662154263a5920a2916cd567)

STAGING:
- [ADF config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/data-federation-config-file/)
- [Search nodes config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/search-nodes-config-file/)
- [OA config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/file-options-online-archive/)
- [Alert config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/alert-config-file/)
- [Cluster config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/cluster-config-file/)
- [Atlas search index config file](https://preview-mongodbsarahsimpers.gatsbyjs.io/atlas-cli/DOCSP-37380/reference/json/search-index-config-file/)