### PR TITLE
DOCSP-40123 -- fix env var flag in example

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -66,7 +66,7 @@ Create a Local Atlas Deployment with Docker
 
             .. code-block:: sh
 
-               docker run -e MONGODB_INITDB_ROOT_USERNAME=user MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
+               docker run -e MONGODB_INITDB_ROOT_USERNAME=user -e MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
 
       The logs display as the Docker image runs.
 


### PR DESCRIPTION
Fix env var flag in example.

- [DOCSP-number](https://jira.mongodb.org/browse/DOCSP-40123)
- [STAGING](https://preview-mongodbjvincentmongodb.gatsbyjs.io/atlas-cli/DOCSP-40123/atlas-cli-deploy-docker/#run-the-docker-image.)

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=667c826debce19f31465d6f6)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

