### PR TITLE
(DOCSP-40965): Moving v1.5 to the Legacy site.

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,6 @@
 name = "atlas-cli"
 title = "Atlas Command Line Interface"
+eol = true
 
 intersphinx = [ "https://www.mongodb.com/docs/ops-manager/current/objects.inv",            
                 "https://www.mongodb.com/docs/manual/objects.inv",
@@ -120,4 +121,11 @@ value = """\
     functionality doesn't include CLI commands. When we introduce a \ 
     new set of CLI commands for our new Data Lake functionality, we \
     will reach out to you to prevent any interruption of service.\
+    """
+
+[[banners]]
+targets = ["*"]
+variant = "info"
+value = """\
+    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of the Atlas CLI <https://www.mongodb.com/docs/atlas/cli/current/install-atlas-cli>`__.\
     """


### PR DESCRIPTION
@melissamahoney-mongodb, I'm moving v1.5 to the Legacy site.

[DOCSP-40965](https://jira.mongodb.org/browse/DOCSP-40965)

[STAGING](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-40965/)

[LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=667d7199ebce19f31496ff73)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

