### PR TITLE
DOCSP-38355 -- add SEO content to reference.txt

### DIFF
--- a/source/reference.txt
+++ b/source/reference.txt
@@ -9,7 +9,7 @@ accept the ``--file`` option.
 Section Overview
 ----------------
 
-:ref:`|json| <json-cluster-config>`
+:ref:`JSON <json-cluster-config>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Learn how to pass configuration values to the {+atlas-cli+} with 

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -3,6 +3,20 @@
 Reference
 =========
 
+You can pass a ``.json`` configuration file to {+atlas-cli+} commands that 
+accept the ``--file`` option. 
+
+Section Overview
+----------------
+
+:ref:`|json| <json-cluster-config>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Learn how to pass configuration values to the {+atlas-cli+} with 
+the ``--file`` option.
+
+
+
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
Add SEO content to reference.txt

- [DOCSP-number](https://jira.mongodb.org/browse/DOCSP-38355)
- [STAGING](https://preview-mongodbjvincentmongodb.gatsbyjs.io/atlas-cli/DOCSP-38355/reference/)

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=668437e9fe162e50061fc245)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

