### PR TITLE
DOCSP-41112 -- Update local dev prereqs from Podman to Docker

### DIFF
--- a/source/includes/fact-deploy-tutorial-prereqs.rst
+++ b/source/includes/fact-deploy-tutorial-prereqs.rst
@@ -62,4 +62,4 @@ Before you begin, complete the following prerequisites:
      Docker requires a network connection for pulling and caching 
      MongoDB images.
 
-     `Podman <https://podman.io>`__ is also supported for Linux RHEL versions. 
+     `Podman <https://podman.io>`__ is also supported for Linux RHEL versions.  

--- a/source/includes/fact-deploy-tutorial-prereqs.rst
+++ b/source/includes/fact-deploy-tutorial-prereqs.rst
@@ -52,15 +52,14 @@ Before you begin, complete the following prerequisites:
   other operating systems, see :dbtools:`Installing the Database Tools 
   </installation/installation/>`.
 
-- Install `Podman <https://podman.io/>`__ version 4.4 and later.
+- Install `Docker <https://www.docker.com//>`__.
 
-  **Example (MacOS):**
-
-  .. code-block:: sh
-
-     brew install podman
+  - For MacOS or Windows, install `Docker Desktop v4.31+ <https://docs.docker.com/desktop/release-notes/#4310>`__. 
+  - For Linux, install `Docker Engine v27.0+ <https://docs.docker.com/engine/release-notes/27.0/>`__. 
 
   .. note::
 
-     Podman requires a network connection for pulling and caching 
+     Docker requires a network connection for pulling and caching 
      MongoDB images.
+
+     `Podman <https://podman.io>`__ is also supported for Linux RHEL versions. 

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -19,57 +19,6 @@ Troubleshoot Errors
 Troubleshoot Local Atlas Deployment Issues
 ------------------------------------------
 
-Error: qemu exited unexpectedly with exit code -1, stderr: qemu-system-x86_64: Error: HV_DENIED
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The {+atlas-cli+} uses `Podman <https://podman.io/>`__ and `QEMU 
-<https://www.qemu.org/>`__. We have identified this issue on MacOS x86 
-architectures. To resolve this issue, upgrade to the latest version of 
-QEMU and restart Podman.
-
-Error: exit status 127
-~~~~~~~~~~~~~~~~~~~~~~
-
-This error might occur when you use the ``atlas deployments setup`` 
-command on Ubuntu Linux because of a `known issue 
-<https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394>`__ with 
-Podman. We don't support Ubuntu for local |service| deployments during 
-this Public Preview stage.
-
-MongoNetworkError: connect ECONNREFUSED
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This issue might occur after your machine goes into sleep mode or 
-restarts. When you try to connect to the local |service| deployment, 
-this error occurs.
-
-The {+atlas-cli+} uses `Podman <https://podman.io/>`__ and `QEMU 
-<https://www.qemu.org/>`__ to run dockerized instances of MongoDB. 
-Podman has a daemonless architecture. So, the local MongoDB instances 
-don't restart automatically.
-
-To fix this issue:
-
-1. List the available deployments.
-
-   .. code-block:: sh
-
-      atlas deployments list
-
-#. To resume the container, copy and paste the following command into 
-   your terminal, and replace ``{deployment-name}`` with the name of 
-   the deployment to start.
-
-   .. code-block:: sh
-
-      atlas deployments start {deployment-name}
-
-Issues on Windows
-~~~~~~~~~~~~~~~~~
-
-We don't support Windows for local |service| deployments during this 
-Public Preview stage.
-
 Local Machine Issues
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -77,70 +26,25 @@ If the {+atlas-cli+} slows down to an unusable state after you create
 multiple local |service| deployments and load data, you might have 
 reached the limits of your machine.
 
-Consider allocating more memory:
+If you're working on Docker Desktop for `Windows <https://docs.docker.com/desktop/settings/windows/#resources>`__ 
+or `MacOS <https://docs.docker.com/desktop/settings/mac/#resources>`__, consider allocating 
+more memory.
 
-1. Stop the Podman machine:
-
-   .. code-block:: sh
-
-      podman machine stop
-
-#. Allocate more memory based on your machine settings:
-
-   .. code-block:: sh
-
-      podman machine set --cpus 3 --memory 5120
-
-#. Start the Podman machine:
-
-   .. code-block:: sh
-
-      podman machine start
-
-#. List the Podman containers.
-
-   .. code-block:: sh
-
-      podman ps --all
-
-#. To resume the container, copy and paste the following command into 
-   your terminal and replace ``{container-name}`` with the name of the 
-   container to start.
-
-   .. code-block:: sh
-
-      podman start {container-name}
-
-Podman Issues
+Docker Issues
 ~~~~~~~~~~~~~
 
-The {+atlas-cli+} uses `Podman <https://podman.io/>`__ for
+The {+atlas-cli+} uses `Docker <https://www.docker.com/>`__ for
 ``atlas deployments`` commands.
 
-To install Podman, run the following command:
-
-.. code-block:: sh
-
-   brew install podman
-
-To initialize a Podman machine, run the following command:
-
-.. code-block:: sh
-
-   podman machine init
-
-To start a Podman machine, run the following command:
-
-.. code-block::
-
-   podman machine start
+- For MacOS or Windows, install `Docker Desktop v4.31+ <https://docs.docker.com/desktop/release-notes/#4310>`__. 
+- For Linux, install `Docker Engine v27.0+ <https://docs.docker.com/engine/release-notes/27.0/>`__. 
 
 If your local |service| deployment doesn't work, you might need to 
-clean up your Podman environment and start fresh:
+clean up your Docker environment and start fresh:
 
 .. code-block::
 
-   podman kill --all && podman system prune --force && podman volume rm --all
+   docker stop $(docker ps -a -q) && docker system prune -a
 
 Run Diagnostics
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Update local dev prereqs and troubleshooting from Podman to Docker.

- [DOCSP-number](https://jira.mongodb.org/browse/DOCSP-41112)
- STAGING 
    - https://preview-mongodbjvincentmongodb.gatsbyjs.io/atlas-cli/DOCSP-41112/atlas-cli-deploy-local/#complete-the-prerequisites
    - https://preview-mongodbjvincentmongodb.gatsbyjs.io/atlas-cli/DOCSP-41112/troubleshooting/

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=668c6078fb8bd13b843b83c2)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

