### PR TITLE
(DOCSP-42635) Archives version 1.10 and backports build fixes

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,6 @@
 name = "atlas-cli"
 title = "Atlas Command Line Interface"
+eol = true
 
 intersphinx = [ "https://www.mongodb.com/docs/ops-manager/current/objects.inv",            
                 "https://www.mongodb.com/docs/manual/objects.inv",
@@ -126,4 +127,11 @@ value = """\
     functionality doesn't include CLI commands. When we introduce a \ 
     new set of CLI commands for our new Data Lake functionality, we \
     will reach out to you to prevent any interruption of service.\
+    """
+
+[[banners]]
+targets = ["*"]
+variant = "info"
+value = """\
+    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of Atlas CLI <https://www.mongodb.com/docs/atlas/cli/current/install-atlas-cli/#update-the-atlas-cli>`__.\
     """

--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -39,7 +39,7 @@ Released 20 July 2023
 - Fixes issue with the printed table format for the
   :ref:`atlas-networking-containers-list` command. 
 - Removes support for MongoDB 4.2.
-- Configures :ref:`atlas-quickstart` command as an alias for the
+- Configures ``atlas quickstart`` command as an alias for the
   :ref:`atlas-setup` command. 
 - Fixes the :ref:`atlas-backups-restores-watch` command output format. 
 - Fixes the :ref:`atlas-backups-restores-watch` command to work
@@ -80,7 +80,7 @@ Released 29 June 2023
   - :ref:`atlas-dataFederation-queryLimits`
 
 - Adds the ``--tag`` flag to the :ref:`atlas-setup` and
-  :ref:`atlas-quickstart` commands.
+  ``atlas quickstart`` commands.
 - Updates a namespace to be optional for performance advisor operations.
 - Fixes the :ref:`atlas-clusters-update` and :ref:`atlas-serverless-update`
   commands ignoring the ``--tag`` flag.
@@ -505,7 +505,7 @@ Released 16 June 2022
   with the {+atlas-cli+} <install-atlas-cli>` using a new meta-package
   for Linux package managers (``apt`` and ``yum``).
 - Automatically detects {+mongosh+} when you use the
-  :ref:`atlas-quickstart` command.
+  ``atlas quickstart`` command.
 
 .. _atlas-cli-1.1.3:
 
@@ -514,7 +514,7 @@ Released 16 June 2022
 
 Released 13 June 2022
 
-- Improves the :ref:`atlas-quickstart` command:
+- Improves the ``atlas quickstart`` command:
 
   - Prompts you to log in if you aren't already logged in.
   - Clarifies an error message when no regions are found for a given cloud
@@ -576,7 +576,7 @@ Changes
     {+cluster+}.
 
 - Adds :ref:`telemetry <telemetry>` to the {+atlas-cli+}.
-- Adds the ``--currentIp`` flag to the :ref:`atlas-quickstart` and
+- Adds the ``--currentIp`` flag to the ``atlas quickstart`` and
   :ref:`atlas-setup` commands. ``--currentIp`` indicates whether to use
   the IP address of the host that is currently executing the command.
 
@@ -591,14 +591,14 @@ Released 28 April 2022
 Changes
 ~~~~~~~
 
-- Improves :ref:`atlas-quickstart` commands:
+- Improves ``atlas quickstart`` commands:
 
-  - Clusters created using :ref:`atlas-quickstart` now start
+  - Clusters created using ``atlas quickstart`` now start
     with the cluster prefix and five digits.
-  - :ref:`atlas-quickstart` now displays a default cluster
+  - ``atlas quickstart`` now displays a default cluster
     option before starting interactive setup.
   - {+atlas-cli+} automatically identifies the ``mongosh`` path for
-    :ref:`atlas-config` and :ref:`atlas-quickstart` commands.
+    :ref:`atlas-config` and ``atlas quickstart`` commands.
 
 - Makes minor improvements to the {+atlas-cli+} documentation.
 

--- a/source/atlas-cli-ephemeral-cluster.txt
+++ b/source/atlas-cli-ephemeral-cluster.txt
@@ -69,13 +69,13 @@ Follow These Steps
          Alternatively, you can use the :ref:`atlas-projects-list`
          command to find the project ID.
 
-      d. Run the :ref:`atlas-quickstart` command to create an ``M10``
+      d. Run the :ref:`atlas-setup` command to create an ``M10``
          {+cluster+} and a database user. Replace <YOUR-PASSWORD> with a password for the database user and replace <PROJECT-ID> with
          the project ID for the ephemeral project you created.
 
          .. code-block::
 
-            atlas quickstart --clusterName myEphemeralCluster --provider AWS --region US_EAST_1 --tier M10 --username myEphemeralUser --password <YOUR-PASSWORD> --currentIp --skipSampleData --projectId <PROJECT-ID> --force
+            atlas setup --clusterName myEphemeralCluster --provider AWS --region US_EAST_1 --tier M10 --username myEphemeralUser --password <YOUR-PASSWORD> --currentIp --skipSampleData --projectId <PROJECT-ID> --force
 
          After |service| creates the {+cluster+}, the {+atlas-cli+}
          provides the :manual:`connection string 


### PR DESCRIPTION
[DOCSP](https://jira.mongodb.org/browse/DOCSP-42635), plus backports https://github.com/mongodb/docs-atlas-cli/pull/447
See Netlify links for staging and build