### PR TITLE
(DOCSP-41388): Updated install steps to remove deprecated apt-key.

### DIFF
--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -59,11 +59,11 @@ To check whether your operating system is compatible with the
       Complete the Prerequisites
       ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      To install the {+atlas-cli+} using Apt, you must install ``gnupg``:
+      To install the {+atlas-cli+} using Apt, you must install ``gnupg`` and ``curl``:
 
       .. code-block:: sh
          
-         sudo apt-get install gnupg
+         sudo apt-get install gnupg curl
 
    .. tab:: Chocolatey
       :tabid: chocolatey
@@ -267,7 +267,9 @@ Follow These Steps
 
             .. code-block:: sh
      
-               wget -qO - https://pgp.mongodb.com/server-{+mdbVersion+}.asc | sudo apt-key add -
+               curl -fsSL https://pgp.mongodb.com/server-{+mdbVersion+}.asc | \
+                  sudo gpg -o /usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg \
+                  --dearmor
      
             A successful command returns an ``OK``.
 

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -300,21 +300,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: comm-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: comm-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdbVersion+}.list
 
                      .. tab:: Debian
                         :tabid: debian
@@ -369,21 +369,21 @@ Follow These Steps
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 20.04 (Focal)
                               :tabid: ent-focal
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.com/apt/ubuntu focal/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                            .. tab:: Ubuntu 18.04 (Bionic)
                               :tabid: ent-bionic
 
                               .. code-block:: sh
 
-                                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
+                                 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-{+mdbVersion+}.gpg ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/{+mdbVersion+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise.list
 
                      .. tab:: Debian
                         :tabid: debian


### PR DESCRIPTION
@sarahsimpers and @gssbzn, I updated the steps to remove the deprecated `apt-key`.

<!-- Add a description of your PR here (optional) -->

- [DOCSP-41388](https://jira.mongodb.org/browse/DOCSP-41388)
- [STAGING](https://preview-mongodbcorryroot.gatsbyjs.io/atlas-cli/DOCSP-41388/install-atlas-cli/#complete-the-prerequisites-1)

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66c5eaa340f3e3c873e186b1)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

