### PR TITLE
DOCSP-43190 -- Add Automation example for local Atlas instance in Docker

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -71,6 +71,14 @@ Create a Local Atlas Deployment with Docker
          .. tab:: Automate Connection
             :tabid: automate-connection
 
+            To automate a containerized deployment of Atlas, you'll need to wait 
+            for the container to be in a healthy state before you can connect to Atlas. 
+
+            The following example demonstrates deploying an Atlas image in Docker
+            and polling Docker to check the state of the container. Once the 
+            container is in a healthy state, the script atuomates a connection 
+            to your Atlas instance with Mongosh. 
+
             a. Create a file called ``mongodb-atlas-local.sh``, and paste the 
                following script into your new file. 
 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -71,9 +71,7 @@ Create a Local Atlas Deployment with Docker
          .. tab:: Automate Connection
             :tabid: automate-connection
 
-            a. Paste the following script into a local file. 
-
-               Create a file called ``mongodb-atlas-local.sh``, and paste the 
+            a. Create a file called ``mongodb-atlas-local.sh``, and paste the 
                following script into your new file. 
 
                .. code-block:: sh
@@ -120,9 +118,7 @@ Create a Local Atlas Deployment with Docker
                   # example usage of the connection string to connect to mongosh
                   mongosh "$CONNECTION_STRING"
 
-            b. Make the file executable. 
-
-               Run the following command to update the permissions on the file. 
+            b. Run the following command to make the file executable. 
 
                .. code-block:: sh
 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -71,7 +71,7 @@ Create a Local Atlas Deployment with Docker
          .. tab:: Automate Connection
             :tabid: automate-connection
 
-            .. step:: Paste the following script into a local file. 
+            a. Paste the following script into a local file. 
 
                Create a file called ``mongodb-atlas-local.sh``, and paste the 
                following script into your new file. 
@@ -120,7 +120,7 @@ Create a Local Atlas Deployment with Docker
                   # example usage of the connection string to connect to mongosh
                   mongosh "$CONNECTION_STRING"
 
-            .. step:: Make the file executable. 
+            b. Make the file executable. 
 
                Run the following command to update the permissions on the file. 
 
@@ -128,7 +128,7 @@ Create a Local Atlas Deployment with Docker
 
                   chmod +x mongodb-atlas-local.sh
 
-            .. step:: Run the executable. 
+            c. Run the executable. 
 
                .. code-block:: sh
 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -30,7 +30,7 @@ Docker.
 
 .. _atlas-cli-deploy-docker-setup:
 
-Create a Local Atlas Deployment with Docker
+Create a Local |service| Deployment with Docker
 -------------------------------------------
       
 .. procedure::
@@ -71,20 +71,20 @@ Create a Local Atlas Deployment with Docker
          .. tab:: Automate Connection
             :tabid: automate-connection
 
-            To automate a containerized deployment of Atlas, you'll need to wait 
-            for the container to be in a healthy state before you can connect to Atlas. 
+            To automate a containerized deployment of |service|, you'll need to wait 
+            for the container to be in a healthy state before you can connect to |service|. 
 
-            The following example demonstrates deploying an Atlas image in Docker
+            The following example demonstrates deploying an |service| image in Docker
             and polling Docker to check the state of the container. Once the 
-            container is in a healthy state, the script atuomates a connection 
-            to your Atlas instance with Mongosh. 
+            container is in a healthy state, the script automates a connection 
+            to your |service| instance with `Mongosh <https://www.mongodb.com/docs/mongodb-shell/install/>`__. 
 
             a. Create a file called ``mongodb-atlas-local.sh``, and paste the 
                following script into your new file. 
 
                .. code-block:: sh
 
-                  # start mongodb-atlas-local container
+                  # Start mongodb-atlas-local container
                   echo "Starting the container"
                   CONTAINER_ID=$(docker run --rm -d -P mongodb/mongodb-atlas-local:latest)
                   
@@ -120,10 +120,10 @@ Create a Local Atlas Deployment with Docker
                   wait "$CONTAINER_ID"
                   EXPOSED_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "27017/tcp") 0).HostPort }}' "$CONTAINER_ID")
                   
-                  # build the connectionstring
+                  # Build the connectionstring
                   CONNECTION_STRING="mongodb://127.0.0.1:$EXPOSED_PORT/test?directConnection=true"
                   
-                  # example usage of the connection string to connect to mongosh
+                  # Example usage of the connection string to connect to mongosh
                   mongosh "$CONNECTION_STRING"
 
             b. Run the following command to make the file executable. 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -54,21 +54,85 @@ Create a Local Atlas Deployment with Docker
 
       .. tabs::
 
-         .. tab:: No Authentication
+         .. tab:: Manually Connect with No Authentication
             :tabid: no-auth
 
             .. code-block:: sh
 
                docker run -p 27017:27017 mongodb/mongodb-atlas-local
 
-         .. tab:: With Authentication
+         .. tab:: Manually Connect with Authentication
             :tabid: with-auth
 
             .. code-block:: sh
 
                docker run -e MONGODB_INITDB_ROOT_USERNAME=user -e MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
 
-      The logs display as the Docker image runs.
+         .. tab:: Automate Connection to Running Container
+            :tabid: automate-connection
+
+            .. step:: Paste the following script into a local file. 
+
+               Create a file called ``mongodb-atlas-local.sh``, and paste the 
+               following script into your new file. 
+
+               .. code-block:: sh
+
+                  # start mongodb-atlas-local container
+                  echo "Starting the container"
+                  CONTAINER_ID=$(docker run --rm -d -P mongodb/mongodb-atlas-local:latest)
+                  
+                  echo "waiting for container to become healthy..."
+                  function wait() {
+                  CONTAINER_ID=$1
+                  echo "waiting for container to become healthy..."
+                  for _ in $(seq 120); do
+                        STATE=$(docker inspect -f '{{ .State.Health.Status }}' "$CONTAINER_ID")
+                  
+                        case $STATE in
+                        healthy)
+                           echo "container is healthy"
+                           return 0
+                           ;;
+                        unhealthy)
+                           echo "container is unhealthy"
+                           docker logs "$CONTAINER_ID"
+                           stop
+                           exit 1
+                           ;;
+                        *)
+                        sleep 1
+                        esac     
+                  done
+                  
+                  echo "container did not get healthy within 120 seconds, quitting"
+                  docker logs mongodb_atlas_local
+                  stop
+                  exit 2
+                  }
+                  
+                  wait "$CONTAINER_ID"
+                  EXPOSED_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "27017/tcp") 0).HostPort }}' "$CONTAINER_ID")
+                  
+                  # build the connectionstring
+                  CONNECTION_STRING="mongodb://127.0.0.1:$EXPOSED_PORT/test?directConnection=true"
+                  
+                  # example usage of the connection string to connect to mongosh
+                  mongosh "$CONNECTION_STRING"
+
+            .. step:: Make the file executable. 
+
+               Run the following command to update the permissions on the file. 
+
+               .. code-block:: sh
+
+                  chmod +x mongodb-atlas-local.sh
+
+            .. step:: Run the executable. 
+
+               .. code-block:: sh
+
+                  ./mongodb-atlas-local.sh
 
    .. step:: Connect to the local |service| deployment.
 

--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -54,21 +54,21 @@ Create a Local Atlas Deployment with Docker
 
       .. tabs::
 
-         .. tab:: Manually Connect with No Authentication
+         .. tab:: Manually Connect no Auth
             :tabid: no-auth
 
             .. code-block:: sh
 
                docker run -p 27017:27017 mongodb/mongodb-atlas-local
 
-         .. tab:: Manually Connect with Authentication
+         .. tab:: Manually Connect with Auth
             :tabid: with-auth
 
             .. code-block:: sh
 
                docker run -e MONGODB_INITDB_ROOT_USERNAME=user -e MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
 
-         .. tab:: Automate Connection to Running Container
+         .. tab:: Automate Connection
             :tabid: automate-connection
 
             .. step:: Paste the following script into a local file. 


### PR DESCRIPTION
Add Automation example for local Atlas instance in Docker.

- [DOCSP-number](https://jira.mongodb.org/browse/DOCSP-43190)
- [STAGING](https://preview-mongodbjvincentmongodb.gatsbyjs.io/atlas-cli/DOCSP-43190/atlas-cli-deploy-docker/#run-the-docker-image.) Under the tab "Automate Connection"

- [LATEST BUILD LOG](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66e339731b6f794a2e79a6f9)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

