### PR TITLE
add banner to local deployment pages-v1.20-backport (642)

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -122,3 +122,11 @@ value = """\
     **Data Lake is deprecated.** \
     As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see :adl:`Migration Guide </data-lake-deprecation/>`\
     """
+
+[[banners]]
+targets = ["command/atlas-deployments*.txt"]
+variant = "warning"
+value = """\
+    **Public Preview.** \
+    The ``atlas deployments`` command and subsequent related commands are available as a Public Preview. The feature and corresponding documentation may change at any time in the Public Preview stage. To ask questions and provide feedback, see the `Atlas CLI Local Development Community Forum <https://www.mongodb.com/community/forums/tag/local-dev-atlas-cli>`__.\
+    """


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.20`:
 - [add banner to local deployment pages (#642)](https://github.com/mongodb/docs-atlas-cli/pull/642)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)