### PR TITLE
DOCSP-43449 updated text for nLogs param

### DIFF
--- a/source/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/source/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -52,7 +52,7 @@ Options
    * - --nLog
      - int
      - false
-     - Maximum number of log lines to return. This value defaults to 20000.
+     - Maximum number of log lines to return, up to a maximum of 20000. This value defaults to 20000.
    * - --namespaces
      - strings
      - false


### PR DESCRIPTION
<!-- Add a description of your PR here (optional) -->

Updated the description of the nLog parameter to state the maximum value. (The description I choose is based on how I saw other places in the docs here talk about maximum values.

Note: Will backport this all the way to v1.21 after this PR is merged.

- [DOCSP-43449](https://jira.mongodb.org/browse/DOCSP-43449)
- [STAGING](https://deploy-preview-663--docs-atlas-cli.netlify.app/command/atlas-performanceAdvisor-slowQueryLogs-list/#options)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [x] Resolve any new warnings or errors in the build.
- [x] Proofread for spelling and grammatical errors.
- [x] Check staging for rendering issues.
- [x] Confirm links are working.

