### PR TITLE
(DOCSP-42975) [Atlas CLI] Atlas CLI nested components-v1.19-backport (677)

### DIFF
--- a/source/atlas-cli-env-variables.txt
+++ b/source/atlas-cli-env-variables.txt
@@ -119,46 +119,41 @@ The {+atlas-cli+} supports the following environment variables:
      - The absolute |url| or the hostname and port in the 
        ``hostname[:port]`` format. 
 
-       .. example:: 
+       The following examples show how to set up the environment
+       variable in different situations:
 
-          The following example shows how to set up the environment 
-          variable if your proxy configuration doesn't require 
-          authentication.
+       - If your proxy configuration doesn't require authentication: 
 
-          .. code-block:: sh 
-             :copyable: false 
+         .. code-block:: sh 
+            :copyable: false 
 
-             HTTP_PROXY=<my.proxy.address>
+            HTTP_PROXY=<my.proxy.address>
 
-          The following example shows how to set up the environment 
-          variable if your proxy configuration requires authentication.
+       - If your proxy configuration requires authentication:
 
-          .. code-block:: sh 
-             :copyable: false 
+         .. code-block:: sh 
+            :copyable: false 
 
-             HTTP_PROXY=<username>:<password>@<my.proxy.address>
+            HTTP_PROXY=<username>:<password>@<my.proxy.address>
 
-          The following example shows how to set up the environment 
-          variable if the scheme is ``socks5``.
+       - If the scheme is ``socks5``:
 
-          .. code-block:: sh 
-             :copyable: false 
+         .. code-block:: sh 
+            :copyable: false 
 
-             HTTP_PROXY=socks5://<my.proxy.address>
+            HTTP_PROXY=socks5://<my.proxy.address>
 
    * - ``HTTPS_PROXY``
      - The absolute |url|. If ``HTTP_PROXY`` is also set, this takes 
        precedence over ``HTTP_PROXY`` for all requests.
 
-       .. example:: 
+       The following example shows how to set up the environment 
+       variable:
 
-          The following example shows how to set up the environment 
-          variable.
+       .. code-block:: sh 
+          :copyable: false 
 
-          .. code-block:: sh 
-             :copyable: false 
-
-             HTTPS_PROXY=https://<my.proxy.address>
+          HTTPS_PROXY=https://<my.proxy.address>
 
    * - ``NO_PROXY``
      - Indicates no proxy for the |url| because proxy isn't configured 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.19`:
 - [(DOCSP-42975) [Atlas CLI] Atlas CLI nested components (#677)](https://github.com/mongodb/docs-atlas-cli/pull/677)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)