### PR TITLE
(DOCSP-42975) [Atlas CLI] Atlas CLI nested components-v1.12-backport (677)

### DIFF
--- a/source/atlas-cli-env-variables.txt
+++ b/source/atlas-cli-env-variables.txt
@@ -114,3 +114,47 @@ The {+atlas-cli+} supports the following environment variables:
 
        You can also enable or disable telemetry with ``DO_NOT_TRACK``,
        but you don't need to specify both.
+
+   * - ``HTTP_PROXY``
+     - The absolute |url| or the hostname and port in the 
+       ``hostname[:port]`` format. 
+
+       The following examples show how to set up the environment
+       variable in different situations:
+
+       - If your proxy configuration doesn't require authentication: 
+
+         .. code-block:: sh 
+            :copyable: false 
+
+            HTTP_PROXY=<my.proxy.address>
+
+       - If your proxy configuration requires authentication:
+
+         .. code-block:: sh 
+            :copyable: false 
+
+            HTTP_PROXY=<username>:<password>@<my.proxy.address>
+
+       - If the scheme is ``socks5``:
+
+         .. code-block:: sh 
+            :copyable: false 
+
+            HTTP_PROXY=socks5://<my.proxy.address>
+
+   * - ``HTTPS_PROXY``
+     - The absolute |url|. If ``HTTP_PROXY`` is also set, this takes 
+       precedence over ``HTTP_PROXY`` for all requests.
+
+       The following example shows how to set up the environment 
+       variable:
+
+       .. code-block:: sh 
+          :copyable: false 
+
+          HTTPS_PROXY=https://<my.proxy.address>
+
+   * - ``NO_PROXY``
+     - Indicates no proxy for the |url| because proxy isn't configured 
+       for the |url|.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.12`:
 - [(DOCSP-42975) [Atlas CLI] Atlas CLI nested components (#677)](https://github.com/mongodb/docs-atlas-cli/pull/677)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)