### PR TITLE
DOCSP-42444 updated troubleshooting page with podman error

### DIFF
--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -97,6 +97,8 @@ Released 25 July 2024
   and :compass:`Compass </>` on Windows.
 - Updates the :ref:`atlas-deployments-setup` command to always use the
   latest image when creating a new local deployment.
+- Drops support for MongoDB 6.0 for local deployments.
+- Drops support for local deployments created with earlier versions of the {+atlas-cli+}.
 - Fixes a bug in the :ref:`atlas-deployments-setup` command where the
   {+atlas-cli+} deletes an existing local deployment when you run this
   command twice for the same deployment.

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -201,6 +201,25 @@ Alert Config Not Deleted
 This error might appear if the {+atlas-cli+} can't delete the alert
 configuration specified by the ID. 
 
+podman not found
+~~~~~~~~~~~~~~~~
+
+This error appears if you try to run an ``atlas deployments`` command
+inside our official docker container, ``mongodb/atlas`` in v1.26 or
+later. Instead, follow the steps decribed in
+:ref:`atlas-cli-deploy-docker`.
+
+You should also inspect past containers and remove any that start with
+``mongod`` or ``mongot`` in your {+cluster+} with the following command:
+
+.. code-block::
+
+   podman ps
+
+.. tip::
+
+   You can safely uninstall podman if you're on MacOS.
+
 Configuration Errors
 --------------------
 

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -209,16 +209,29 @@ inside our official docker container, ``mongodb/atlas`` in v1.26 or
 later. Instead, follow the steps decribed in
 :ref:`atlas-cli-deploy-docker`.
 
-You should also inspect past containers and remove any that start with
-``mongod`` or ``mongot`` in your {+cluster+} with the following command:
+You should inspect past containers in your {+cluster+} with the
+following command:
 
 .. code-block::
 
-   podman ps
+   podman ps -a
+
+Then, remove any that start with ``mongod`` or ``mongot`` with the
+following command:
+
+.. code-block::
+
+   podman container rm -f -v <name or ID>
 
 .. tip::
 
    You can safely uninstall podman if you're on MacOS.
+
+   If you installed podman with homebrew, use this command to uninstall:
+
+   .. code-block::
+
+      brew uninstall podman
 
 Configuration Errors
 --------------------


### PR DESCRIPTION
<!-- Add a description of your PR here (optional) -->

Updated the troubleshooting page to contain a podman error, and updated the v1.26 rn with 2 additional bullets.

Note: I'll backport this to v1.26 after this PR is merged.

- [DOCSP-42444](https://jira.mongodb.org/browse/DOCSP-42444)
- STAGING
  - [Troubleshooting](https://deploy-preview-708--docs-atlas-cli.netlify.app/troubleshooting/#podman-not-found)
  - [v1.26 release notes](https://deploy-preview-708--docs-atlas-cli.netlify.app/atlas-cli-changelog/#atlas-cli-1.26.0)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [x] Resolve any new warnings or errors in the build.
- [x] Proofread for spelling and grammatical errors.
- [x] Check staging for rendering issues.
- [x] Confirm links are working.

