### PR TITLE
DOCSP-44126-ToC-Refactor-v1.13-backport (709)

### DIFF
--- a/source/atlas-cli-tutorials.txt
+++ b/source/atlas-cli-tutorials.txt
@@ -55,7 +55,7 @@ You can also go straight to the :ref:`{+atlas-cli+} Commands
 .. toctree::
    :titlesonly:
 
-   Get Started with Atlas </atlas-cli-getting-started>
+   Get Started </atlas-cli-getting-started>
    Create & Configure Clusters </atlas-cli-quickstart>
    Cluster Configuration File </atlas-cli-create-cluster-from-config-file>
    Local & Cloud Deployments </atlas-cli-local-cloud>

--- a/source/connect-atlas-cli.txt
+++ b/source/connect-atlas-cli.txt
@@ -230,8 +230,8 @@ different profile, see :ref:`<atlas-cli-profiles>`.
 
 .. toctree::
 
-   /atlas-cli-save-connection-settings
-   /migrate-to-atlas-cli
+   Save Connection Settings </atlas-cli-save-connection-settings>
+   Migrate to the Atlas CLI </migrate-to-atlas-cli>
 
 
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -128,12 +128,12 @@ Learn the {+atlas-cli+} commands and optimize your workflow with advanced tutori
    :titlesonly:
 
    Overview </index>
-   Install or Update the Atlas CLI </install-atlas-cli>
-   Connect from the Atlas CLI </connect-atlas-cli>
+   Install or Update </install-atlas-cli>
+   Connect </connect-atlas-cli>
    Commands </command/atlas>
-   Automate Processes </atlas-cli-automate>
+   Automate </atlas-cli-automate>
    Configure Telemetry </telemetry>
    Manage Atlas </atlas-cli-tutorials>
-   Atlas CLI Reference </reference>
-   Troubleshoot Errors </troubleshooting>
+   Reference </reference>
+   Troubleshoot </troubleshooting>
    Changelog </atlas-cli-changelog>

--- a/source/install-atlas-cli.txt
+++ b/source/install-atlas-cli.txt
@@ -631,4 +631,4 @@ Take the Next Steps
 .. toctree::
    :titlesonly:
 
-   /compatibility
+   Check Compatibility </compatibility>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [DOCSP-44126-ToC-Refactor (#709)](https://github.com/mongodb/docs-atlas-cli/pull/709)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)