### PR TITLE
DOCSP-42971-v1.11-EOL

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -128,7 +128,7 @@ targets = ["command/atlas-deployments*.txt"]
 variant = "warning"
 value = """\
     **Public Preview.** \
-    The ``atlas deployments`` command and subsequent related commands are available as a Public Preview. The feature and corresponding documentation may change at any time in the Public Preview stage. To ask questions and provide feedback, see the `Atlas CLI <https://www.mongodb.com/community/forums/tag/local-dev-atlas-cli>`__.\
+    The ``atlas deployments`` command and subsequent related commands are available as a Public Preview. The feature and corresponding documentation may change at any time in the Public Preview stage. To ask questions and provide feedback, see the `Atlas CLI Local Development Community Forum <https://www.mongodb.com/community/forums/tag/local-dev-atlas-cli>`__.\
     """
 
 [[banners]]
@@ -137,4 +137,3 @@ variant = "info"
 value = """\
     This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of `Atlas CLI <https://www.mongodb.com/products/tools/atlas-cli>`__.\
     """
-For more information 

--- a/snooty.toml
+++ b/snooty.toml
@@ -128,5 +128,13 @@ targets = ["command/atlas-deployments*.txt"]
 variant = "warning"
 value = """\
     **Public Preview.** \
-    The ``atlas deployments`` command and subsequent related commands are available as a Public Preview. The feature and corresponding documentation may change at any time in the Public Preview stage. To ask questions and provide feedback, see the `Atlas CLI Local Development Community Forum <https://www.mongodb.com/community/forums/tag/local-dev-atlas-cli>`__.\
+    The ``atlas deployments`` command and subsequent related commands are available as a Public Preview. The feature and corresponding documentation may change at any time in the Public Preview stage. To ask questions and provide feedback, see the `Atlas CLI <https://www.mongodb.com/community/forums/tag/local-dev-atlas-cli>`__.\
     """
+
+[[banners]]
+targets = ["*"]
+variant = "info"
+value = """\
+    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of `Atlas CLI <https://www.mongodb.com/products/tools/atlas-cli>`__.\
+    """
+For more information 

--- a/snooty.toml
+++ b/snooty.toml
@@ -135,5 +135,5 @@ value = """\
 targets = ["*"]
 variant = "info"
 value = """\
-    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of Atlas CLI <https://www.mongodb.com/products/tools/atlas-cli>`__.\
+    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/install-atlas-cli/>`__ to learn how to upgrade your version of Atlas CLI.\
     """

--- a/snooty.toml
+++ b/snooty.toml
@@ -135,5 +135,5 @@ value = """\
 targets = ["*"]
 variant = "info"
 value = """\
-    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of `Atlas CLI <https://www.mongodb.com/products/tools/atlas-cli>`__.\
+    This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of Atlas CLI <https://www.mongodb.com/products/tools/atlas-cli>`__.\
     """


### PR DESCRIPTION
Adds the EOL banner to v1.11 (Per [these EOL instructions](https://wiki.corp.mongodb.com/display/DE/How+To%3A+Sunset+an+EOL+Version+of+Documentation))

- [DOCSP-43971](https://jira.mongodb.org/browse/DOCSP-43971)
- [STAGING](https://deploy-preview-736--docs-atlas-cli.netlify.app)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

