### PR TITLE
(DOCSP-45098) Updates localdev Docker compose example.-v1.15-backport (760)

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -221,9 +221,10 @@ of Docker Compose.
 
       .. code-block:: sh
          :linenos: 
-         
+
          services:
            mongodb:
+             hostname: mongodb
              image: mongodb/mongodb-atlas-local
              environment:
                - MONGODB_INITDB_ROOT_USERNAME=user
@@ -232,8 +233,10 @@ of Docker Compose.
                - 27019:27017
              volumes:
                - data:/data/db
+               - config:/data/configdb
          volumes:
            data:
+           config:
 
    .. step:: Run Docker Compose.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.15`:
 - [(DOCSP-45098) Updates localdev Docker compose example. (#760)](https://github.com/mongodb/docs-atlas-cli/pull/760)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)