### PR TITLE
(DOCSP-45676), (DOCSP-45679), (DOCSP-45680): Updated Local Deployment page.

### DIFF
--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -119,8 +119,8 @@ mode.
             
                atlas deployments setup
 
-            To initialize the local |service| deployment with data 
-            and indexes: 
+            To initialize the local |service| deployment with your own 
+            data and indexes: 
             
             a. Copy the following command:
 
@@ -130,8 +130,7 @@ mode.
 
             #. Replace the ``{folder}`` placeholder with the directory 
                that contains the ``.js`` and ``.sh`` files to run 
-               inside the local container in alphanumeric order with 
-               ``mongosh`` and ``bash`` respectively.
+               inside the local container in alphanumeric order.
 
             #. Run the command.
 
@@ -198,8 +197,8 @@ mode.
          
                atlas deployments setup
 
-            To initialize the local |service| deployment with data 
-            and indexes: 
+            To initialize the local |service| deployment with your own 
+            data and indexes: 
             
             a. Copy the following command:
 
@@ -209,8 +208,7 @@ mode.
 
             #. Replace the ``{folder}`` placeholder with the directory 
                that contains the ``.js`` and ``.sh`` files to run 
-               inside the local container in alphanumeric order with 
-               ``mongosh`` and ``bash`` respectively.
+               inside the local container in alphanumeric order.
 
             #. Run the command.
 
@@ -329,8 +327,8 @@ mode.
 
                   connection skipped
             
-            To initialize the local |service| deployment with data 
-            indexes: 
+            To initialize the local |service| deployment with your own 
+            data and indexes: 
             
             a. Copy the following command:
 
@@ -340,8 +338,7 @@ mode.
 
             #. Replace the ``{folder}`` placeholder with the directory 
                that contains the ``.js`` and ``.sh`` files to run 
-               inside the local container in alphanumeric order with 
-               ``mongosh`` and ``bash`` respectively.
+               inside the local container in alphanumeric order.
 
             #. Run the command.
 
@@ -475,7 +472,7 @@ a local |service| deployment to a cloud |service| deployment.
             
          atlas deployments setup --type local
       
-      To initialize the local |service| deployment with data 
+      To initialize the local |service| deployment with your own data 
       and indexes: 
             
       a. Copy the following command:
@@ -486,8 +483,7 @@ a local |service| deployment to a cloud |service| deployment.
 
       #. Replace the ``{folder}`` placeholder with the directory 
          that contains the ``.js`` and ``.sh`` files to run 
-         inside the local container in alphanumeric order with 
-         ``mongosh`` and ``bash`` respectively.
+         inside the local container in alphanumeric order.
 
       #. Run the command.
 
@@ -560,7 +556,7 @@ update a local |service| deployment to newer version of the image.
             
          atlas deployments setup --type local
       
-      To initialize the local |service| deployment with data 
+      To initialize the local |service| deployment with your own data 
       and indexes: 
             
       a. Copy the following command:
@@ -571,8 +567,7 @@ update a local |service| deployment to newer version of the image.
 
       #. Replace the ``{folder}`` placeholder with the directory 
          that contains the ``.js`` and ``.sh`` files to run 
-         inside the local container in alphanumeric order with 
-         ``mongosh`` and ``bash`` respectively.
+         inside the local container in alphanumeric order.
 
       #. Run the command.
 

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -119,6 +119,22 @@ mode.
             
                atlas deployments setup
 
+            To initialize the local |service| deployment with data 
+            and indexes: 
+            
+            a. Copy the following command:
+
+               .. code-block:: sh
+
+                  atlas deployments setup --initdb {folder}
+
+            #. Replace the ``{folder}`` placeholder with the directory 
+               that contains the ``.js`` and ``.sh`` files to run 
+               inside the local container in alphanumeric order with 
+               ``mongosh`` and ``bash`` respectively.
+
+            #. Run the command.
+
          .. step:: Specify what to deploy.
 
             **Example:**
@@ -181,6 +197,22 @@ mode.
             .. code-block:: sh
          
                atlas deployments setup
+
+            To initialize the local |service| deployment with data 
+            and indexes: 
+            
+            a. Copy the following command:
+
+               .. code-block:: sh
+
+                  atlas deployments setup --initdb {folder}
+
+            #. Replace the ``{folder}`` placeholder with the directory 
+               that contains the ``.js`` and ``.sh`` files to run 
+               inside the local container in alphanumeric order with 
+               ``mongosh`` and ``bash`` respectively.
+
+            #. Run the command.
 
          .. step:: Specify what to deploy.
 
@@ -296,6 +328,22 @@ mode.
                   Connection string: mongodb://localhost:49684/?directConnection=true
 
                   connection skipped
+            
+            To initialize the local |service| deployment with data 
+            indexes: 
+            
+            a. Copy the following command:
+
+               .. code-block:: sh
+
+                  atlas deployments setup myLocalRs1 --type local --force --initdb {folder}
+
+            #. Replace the ``{folder}`` placeholder with the directory 
+               that contains the ``.js`` and ``.sh`` files to run 
+               inside the local container in alphanumeric order with 
+               ``mongosh`` and ``bash`` respectively.
+
+            #. Run the command.
 
 .. _atlas-cli-deploy-local-manage:
 
@@ -402,6 +450,182 @@ atlas deployments respectively.
       #. Specify the deployment to delete and press :kbd:`Enter`.. 
    
       #. Specify ``y`` and press :kbd:`Enter`. to confirm.
+
+.. _atlas-cli-move-local-to-cloud:
+
+Move a Local Atlas Deployment to a Cloud Atlas Deployment
+---------------------------------------------------------
+
+You can use `Docker <https://www.docker.com/>`__ and 
+:dbtools:`MongoDB Database Tools </installation/installation/>` to move 
+a local |service| deployment to a cloud |service| deployment.
+
+.. procedure::
+   :style: normal
+
+   .. step:: Create a cloud |service| deployment.
+
+      .. code-block:: sh
+            
+         atlas deployments setup --type atlas
+
+   .. step:: Create a local |service| deployment.
+
+      .. code-block:: sh
+            
+         atlas deployments setup --type local
+      
+      To initialize the local |service| deployment with data 
+      and indexes: 
+            
+      a. Copy the following command:
+
+         .. code-block:: sh
+
+            atlas deployments setup --type local --initdb {folder}
+
+      #. Replace the ``{folder}`` placeholder with the directory 
+         that contains the ``.js`` and ``.sh`` files to run 
+         inside the local container in alphanumeric order with 
+         ``mongosh`` and ``bash`` respectively.
+
+      #. Run the command.
+
+   .. step:: Create a binary file of the data.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            docker exec -u root -it {local_deployment_name} sh -c "mkdir -p /data/dump && chown -R mongod:mongod /data/dump && mongodump --archive=/data/dump/dump.archive"
+
+      #. Replace the ``{local-deployment-name}`` placeholder with the 
+         name of your local |service| deployment.
+
+      #. Run the command.
+
+   .. step:: Copy the archive.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            docker cp <local deployment name>:/data/dump/dump.archive .
+
+      #. Replace the ``{local-deployment-name}`` placeholder with the 
+         name of your local |service| deployment.
+
+      #. Run the command.
+
+   .. step:: Return the connection string.
+
+      .. code-block:: sh
+
+         atlas deployments connect --type atlas --connectWith connectionString
+
+   .. step:: Restore from the archived file.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            mongorestore --uri={connection-string} --archive=./dump.archive
+
+      #. Replace the ``{connection-string}`` placeholder with the 
+         connection string.
+
+      #. Run the command.
+
+   .. step:: (Optional) Delete the local |service| deployment.
+
+      .. code-block:: sh
+
+         atlas deployments delete --type local
+
+.. _atlas-cli-update-local-deployment:
+
+Update a Local Atlas Deployment
+-------------------------------
+
+You can use `Docker <https://www.docker.com/>`__ and 
+:dbtools:`MongoDB Database Tools </installation/installation/>` to 
+update a local |service| deployment to newer version of the image.
+
+.. procedure::
+   :style: normal
+
+   .. step:: Create a new local |service| deployment.
+
+      .. code-block:: sh
+            
+         atlas deployments setup --type local
+      
+      To initialize the local |service| deployment with data 
+      and indexes: 
+            
+      a. Copy the following command:
+
+         .. code-block:: sh
+
+            atlas deployments setup --type local --initdb {folder}
+
+      #. Replace the ``{folder}`` placeholder with the directory 
+         that contains the ``.js`` and ``.sh`` files to run 
+         inside the local container in alphanumeric order with 
+         ``mongosh`` and ``bash`` respectively.
+
+      #. Run the command.
+
+   .. step:: Create a binary file of the data.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            docker exec -u root -it {old-local-deployment-name} sh -c "mkdir -p /data/dump && chown -R mongod:mongod /data/dump && mongodump --archive=/data/dump/dump.archive"
+
+      #. Replace the ``{old-local-deployment-name}`` placeholder with 
+         the name of your old local |service| deployment.
+
+      #. Run the command.
+
+   .. step:: Copy the archive.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            docker cp {old-local-deployment-name}:/data/dump/dump.archive .
+
+      #. Replace the ``{old-local-deployment-name}`` placeholder with 
+         the name of your old local |service| deployment.
+
+      #. Run the command.
+
+   .. step:: Return the new connection string.
+
+      .. code-block:: sh
+
+         atlas deployments connect --type local --connectWith connectionString
+
+   .. step:: Restore from the archived file.
+
+      a. Copy the following command:
+
+         .. code-block:: sh
+      
+            mongorestore --uri={connection-string} --archive=./dump.archive
+
+      #. Replace the ``{connection-string}`` placeholder with the 
+         connection sring.
+
+      #. Run the command.
+
+   .. step:: (Optional) Delete the old local |service| deployment.
+
+      .. code-block:: sh
+
+         atlas deployments delete --type local
 
 .. _atlas-cli-deploy-local-fts:
 

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -545,7 +545,7 @@ Update a Local Atlas Deployment
 
 You can use `Docker <https://www.docker.com/>`__ and 
 :dbtools:`MongoDB Database Tools </installation/installation/>` to 
-update a local |service| deployment to newer version of the image.
+update a local |service| deployment to a newer version of the image.
 
 .. procedure::
    :style: normal


### PR DESCRIPTION
@fmenezes, I've drafted all the updated for the Local Deployment page. Can you provide more information about the `--initdb` option? Where do the `.js` and `.sh` files come from?

<!-- Add a description of your PR here (optional) -->

- [DOCSP-45676](https://jira.mongodb.org/browse/45676)
- [DOCSP-45679](https://jira.mongodb.org/browse/45679)
- [DOCSP-45680](https://jira.mongodb.org/browse/45680)
- [STAGING](https://deploy-preview-784--docs-atlas-cli.netlify.app/atlas-cli-deploy-local/#move-a-local-atlas-deployment-to-a-cloud-atlas-deployment)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

