### PR TITLE
(DOCSP-45896): Adds redirect for page unavailable in version example.

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -22,4 +22,4 @@ raw: docs/atlas/cli/stablecommand/atlas-privateEndpoints-onlineArchive-aws-descr
 
 # Atlas CLI Version 1.13 and earlier
 
-[*-v1.13]: /docs/atlas/cli/${version}/atlas-cli-deploy-docker/ -> https://www.mongodb.com/docs/unavailable-version/
+[*-v1.13]: docs/atlas/cli/${version}/atlas-cli-deploy-docker/ -> https://www.mongodb.com/docs/unavailable-version/

--- a/config/redirects
+++ b/config/redirects
@@ -19,3 +19,7 @@ raw: docs/atlas/cli/stablecommand/atlas-privateEndpoints-onlineArchive-aws-descr
 # Atlas CLI Version 1.6 and later
 
 [v1.6-*]: docs/atlas/cli/${version}/cluster-config-file -> ${base}/${version}/reference/json/cluster-config-file
+
+# Atlas CLI Version 1.13 and earlier
+
+[*-v1.13]: /docs/atlas/cli/v1.14/atlas-cli-deploy-docker/ -> /docs/unavailable-version/

--- a/config/redirects
+++ b/config/redirects
@@ -22,4 +22,4 @@ raw: docs/atlas/cli/stablecommand/atlas-privateEndpoints-onlineArchive-aws-descr
 
 # Atlas CLI Version 1.13 and earlier
 
-[*-v1.13]: /docs/atlas/cli/v1.14/atlas-cli-deploy-docker/ -> /docs/unavailable-version/
+[*-v1.13]: /docs/atlas/cli/${version}/atlas-cli-deploy-docker/ -> https://www.mongodb.com/docs/unavailable-version/


### PR DESCRIPTION
@jwilliams-mongo, I'm trying to set up a redirect to the [Page Unavailable in Version](https://www.mongodb.com/docs/unavailable-version/) page so that I have an example for the Lunch & Learn tomorrow.

<!-- Add a description of your PR here (optional) -->

- [DOCSP-45896](https://jira.mongodb.org/browse/DOCSP-45896)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

