### PR TITLE
(DOCSP-46401) Adds install workaround for m4 chips.-v1.33-backport (809)

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -41,7 +41,7 @@ Create a Local |service| Deployment with Docker
          docker pull mongodb/mongodb-atlas-local:latest
 
    .. step:: Run the Docker image.
-
+        
       **Example:**
 
       .. tabs::
@@ -53,12 +53,16 @@ Create a Local |service| Deployment with Docker
 
                docker run -p 27017:27017 mongodb/mongodb-atlas-local
 
+            .. include:: /includes/fact-installation-workaround-m4chips.rst      
+         
          .. tab:: Manually Connect with Auth
             :tabid: with-auth
 
             .. code-block:: sh
 
                docker run -e MONGODB_INITDB_ROOT_USERNAME=user -e MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
+
+            .. include:: /includes/fact-installation-workaround-m4chips.rst   
 
          .. tab:: Automate Connection
             :tabid: automate-connection

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -91,6 +91,12 @@ Create a Local Atlas Deployment
 Use the ``atlas deployments`` command to create a local |service|
 deployment.
 
+.. important::
+
+   If your local machine runs MacOS Sequoia 15.2 with the Apple Silicon M4 chip, follow the procedure for 
+   :ref:`creating a local Atlas deployment with Docker <atlas-cli-deploy-docker>` 
+   instead of this procedure to avoid the error: ``container configuration failed``.  
+
 You can run this command in the following ways: 
       
 - **Interactive Mode (Default)**: the command prompts you for the 

--- a/source/includes/fact-installation-workaround-m4chips.rst
+++ b/source/includes/fact-installation-workaround-m4chips.rst
@@ -1,0 +1,9 @@
+.. important::
+
+   If your local machine runs MacOS Sequoia 15.2 with the Apple Silicon M4 chip, add the following 
+   :abbr:`JVM (Java Virtual Machine)` parameter to the ``docker run`` command 
+   to prevent your container from crashing upon startup. For example: 
+
+   .. code-block:: sh
+      
+      docker run -e JAVA_TOOL_OPTIONS="-XX:UseSVE=0" -p 27017:27017 mongodb/mongodb-atlas-local


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.33`:
 - [(DOCSP-46401) Adds install workaround for m4 chips. (#809)](https://github.com/mongodb/docs-atlas-cli/pull/809)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)