### PR TITLE
DOCSP-46527 -- Add GitHub access requirement note-v1.16-backport (844)

### DIFF
--- a/source/includes/steps-run-as-daemon.rst
+++ b/source/includes/steps-run-as-daemon.rst
@@ -19,6 +19,10 @@
 
    .. step:: Authenticate and run {+atlas-cli+} commands.
 
+      .. note::
+
+         You must have access to the GitHub API in order to use the Atlas CLI in Docker.
+
       To authenticate and run commands, set up API keys in the `environment file 
       <https://docs.docker.com/engine/reference/commandline/run/#env>`__. 
       To learn more, see 

--- a/source/includes/steps-run-interactive-mode.rst
+++ b/source/includes/steps-run-interactive-mode.rst
@@ -28,6 +28,10 @@
 
    .. step:: Authenticate and run {+atlas-cli+} commands.
 
+      .. note::
+
+         You must have access to the GitHub API in order to use the Atlas CLI in Docker.
+
       To authenticate and run commands, set up API keys in the `environment file 
       <https://docs.docker.com/engine/reference/commandline/run/#env>`__. 
       To learn more, see 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.16`:
 - [DOCSP-46527 -- Add GitHub access requirement note (#844)](https://github.com/mongodb/docs-atlas-cli/pull/844)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)