### PR TITLE
(DOCSP-47205) Fixes build errors.-v1.38-backport (872)

### DIFF
--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -51,7 +51,7 @@ Released 09 January 2025
   Flex Cluster snapshots.
 - Deprecates the following: 
 
-  - :ref:`atlas-serverless` commands 
+  - ``atlas-serverless`` commands 
   - ``M1`` and ``M5`` tiers
 
   .. tip:: 
@@ -83,9 +83,9 @@ Released 18 December 2024
   (before it was only ``.gzip``).
 - Fixes a bug where the ``--mongoDbVersion`` would be ignored for the 
   ``atlas deployments setup`` command with the type: ``atlas``.
-- Supports building the :ref:`atlascustomrole-custom-resource` and
-  :ref:`atlasprivateendpoint-custom-resource` CRDs with the
-  :ref:`altas-kubernetes-apply` and :ref:`atlas-kubernetes-generate` commands.
+- Supports building the `AtlasCustomRole <https://www.mongodb.com/docs/atlas/operator/v2.6/atlascustomrole-custom-resource/>`__ and
+  `AtlasPrivateEndpoint <https://www.mongodb.com/docs/atlas/operator/v2.6/atlasprivateendpoint-custom-resource/>`__ CRDs with the
+  :ref:`atlas-kubernetes-config-apply` and :ref:`atlas-kubernetes-config-generate` commands.
 
 
 .. _atlas-cli-1.33.0:
@@ -637,7 +637,7 @@ Released 29 June 2023
 - Adds the ``--tag`` flag to the :ref:`atlas-setup` and
   ``atlas quickstart`` commands.
 - Updates a namespace to be optional for performance advisor operations.
-- Fixes the :ref:`atlas-clusters-update` and :ref:`atlas-serverless-update`
+- Fixes the :ref:`atlas-clusters-update` and ``atlas-serverless-update``
   commands ignoring the ``--tag`` flag.
 - Deprecates ``atlas datalake`` and ``atlas privateEndpoints`` 
   commands in favor of ``atlas datafederation``.
@@ -652,8 +652,8 @@ Released 18 June 2023
 - Adds the ``LagTime`` and ``ReadyForCutOver`` fields to the
   :ref:`atlas-liveMigrations-create`.
   and :ref:`atlas-liveMigrations-describe` command output.
-- Adds the ``--tag`` flag to the :ref:`atlas-serverless-create` 
-  and :ref:`atlas-serverless-update` commands.
+- Adds the ``--tag`` flag to the ``atlas-serverless-create`` 
+  and ``atlas-serverless-update`` commands.
 - Adds the ``--watch`` flag to the :ref:`atlas-clusters-create` and
   :ref:`atlas-clusters-delete` commands.
 
@@ -799,13 +799,13 @@ Released 30 March 2023
 
 - Adds the following new commands:
 
-  - :ref:`atlas-serverless-backups-snapshots-watch`
-  - :ref:`atlas-serverless-backups-snapshots-list`
-  - :ref:`atlas-serverless-backups-restores-watch`
-  - :ref:`atlas-serverless-backups-restores-create`
-  - :ref:`atlas-serverless-backups-restores-describe`
-  - :ref:`atlas-serverless-backups-restores-list`
-  - :ref:`atlas-serverless-update`
+  - ``atlas-serverless-backups-snapshots-watch``
+  - ``atlas-serverless-backups-snapshots-list``
+  - ``atlas-serverless-backups-restores-watch``
+  - ``atlas-serverless-backups-restores-create``
+  - ``atlas-serverless-backups-restores-describe``
+  - ``atlas-serverless-backups-restores-list``
+  - ``atlas-serverless-update``
   - :ref:`atlas-backups-exports-jobs-watch`
   - :ref:`atlas-organizations-create`
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.38`:
 - [(DOCSP-47205) Fixes build errors. (#872)](https://github.com/mongodb/docs-atlas-cli/pull/872)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)