### PR TITLE
Backports DOCSP-47165 to v1.25-v1.14-backport (899)

### DIFF
--- a/source/atlas-cli-deploy-docker.txt
+++ b/source/atlas-cli-deploy-docker.txt
@@ -60,8 +60,6 @@ Create a Local Atlas Deployment with Docker
             .. code-block:: sh
 
                docker run -p 27017:27017 mongodb/mongodb-atlas-local
-
-            .. include:: /includes/fact-installation-workaround-m4chips.rst      
          
          .. tab:: With Authentication
             :tabid: with-auth
@@ -70,10 +68,8 @@ Create a Local Atlas Deployment with Docker
 
                docker run -e MONGODB_INITDB_ROOT_USERNAME=user -e MONGODB_INITDB_ROOT_PASSWORD=pass -p 27017:27017 mongodb/mongodb-atlas-local
 
-            .. include:: /includes/fact-installation-workaround-m4chips.rst
-
       The logs display as the Docker image runs.
-
+         
    .. step:: Connect to the local |service| deployment.
 
       To connect to the local |service| deployment from the host (not 

--- a/source/atlas-cli-deploy-local.txt
+++ b/source/atlas-cli-deploy-local.txt
@@ -67,13 +67,7 @@ Create a Local Atlas Deployment
 -------------------------------
 
 Use the ``atlas deployments`` command to create a local |service|
-deployment.
-
-.. important::
-
-   If your local machine runs MacOS Sequoia 15.2 with the Apple Silicon M4 chip, follow the procedure for 
-   :ref:`creating a local Atlas deployment with Docker <atlas-cli-deploy-docker>` 
-   instead of this procedure to avoid the error: ``container configuration failed``.  
+deployment. 
 
 You can run this command in the following ways: 
       

--- a/source/includes/fact-installation-workaround-m4chips.rst
+++ b/source/includes/fact-installation-workaround-m4chips.rst
@@ -1,9 +1,0 @@
-.. important::
-
-   If your local machine runs MacOS Sequoia 15.2 with the Apple Silicon M4 chip, add the following 
-   :abbr:`JVM (Java Virtual Machine)` parameter to the ``docker run`` command 
-   to prevent your container from crashing upon startup. For example: 
-
-   .. code-block:: sh
-      
-      docker run -e JAVA_TOOL_OPTIONS="-XX:UseSVE=0" -p 27017:27017 mongodb/mongodb-atlas-local


### PR DESCRIPTION
# Backport

This will backport the following commits from `v1.25` to `v1.14`:
 - [(DOCSP-47165) Removes workaround per fix. (#875) (#899)](https://github.com/mongodb/docs-atlas-cli/pull/899)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)