### PR TITLE
Docsp 46527 -- Add Troubleshooting entry-v1.35-backport (885)

### DIFF
--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -46,6 +46,13 @@ clean up your Docker environment and start fresh:
 
    docker stop $(docker ps -a -q) && docker system prune -a
 
+Failed to Install or Update the AtlasCLI Plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the {+atlas-cli+} plugin fails to install or update, make sure that you have 
+access to the `GitHub API <https://docs.github.com/en/rest>`__, 
+as GitHub API access is required to install or update the {+atlas-cli+} plugin. 
+
 Run Diagnostics
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.35`:
 - [Docsp 46527 -- Add Troubleshooting entry (#885)](https://github.com/mongodb/docs-atlas-cli/pull/885)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)