### PR TITLE
DOCSP-48106 -- add ako dry run commands

### DIFF
--- a/source/command/atlas-kubernetes-dry-run.txt
+++ b/source/command/atlas-kubernetes-dry-run.txt
@@ -1,0 +1,83 @@
+.. _atlas-kubernetes-dry-run:
+
+========================
+atlas kubernetes dry-run
+========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Deploy and run Atlas Kubernetes Operator in dry-run mode
+
+This command deploys the Atlas Kubernetes operator with the DryRun mode.
+
+Syntax
+------
+
+.. code-block::
+   :caption: Command Syntax
+
+   atlas kubernetes dry-run [options]
+
+.. Code end marker, please don't delete this comment
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -h, --help
+     - 
+     - false
+     - help for dry-run
+   * - --operatorVersion
+     - string
+     - false
+     - Version of Atlas Kubernetes Operator to generate resources for. This value defaults to "2.7.0".
+   * - --orgId
+     - string
+     - false
+     - Organization ID to use. This option overrides the settings in the configuration file or environment variable.
+   * - --targetNamespace
+     - string
+     - false
+     - Namespaces to use for generated kubernetes entities
+   * - --watch
+     - 
+     - false
+     - Flag that indicates whether to watch the command until it completes its execution or the watch times out. To set the time that the watch times out, use the --watchTimeout option.
+   * - --watchNamespace
+     - strings
+     - false
+     - List that contains namespaces that the operator will listen to.
+   * - --watchTimeout
+     - int
+     - false
+     - Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command. This value defaults to 120.
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Name of the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings.

--- a/source/command/atlas-kubernetes-dry-run.txt
+++ b/source/command/atlas-kubernetes-dry-run.txt
@@ -12,9 +12,9 @@ atlas kubernetes dry-run
    :depth: 1
    :class: singlecol
 
-Deploy and run Atlas Kubernetes Operator in dry-run mode
+Deploy and run Atlas Kubernetes Operator in dry-run mode.
 
-This command deploys the Atlas Kubernetes operator with the DryRun mode.
+This command deploys the Atlas Kubernetes operator with the dry-run mode.
 
 Syntax
 ------
@@ -52,7 +52,7 @@ Options
    * - --targetNamespace
      - string
      - false
-     - Namespaces to use for generated kubernetes entities
+     - Namespaces to use for generated Kubernetes entities.
    * - --watch
      - 
      - false
@@ -60,7 +60,7 @@ Options
    * - --watchNamespace
      - strings
      - false
-     - List that contains namespaces that the operator will listen to.
+     - List that contains namespaces that the Operator listens to.
    * - --watchTimeout
      - int
      - false

--- a/source/command/atlas-kubernetes-operator-install.txt
+++ b/source/command/atlas-kubernetes-operator-install.txt
@@ -44,6 +44,10 @@ Options
      - 
      - false
      - Flag that indicates whether to configure Atlas for Government as a target of the operator.
+   * - --configOnly
+     - 
+     - false
+     - Flag that indicates whether to generate only the operator configuration files without installing the Operator
    * - -h, --help
      - 
      - false

--- a/source/command/atlas-kubernetes-operator-install.txt
+++ b/source/command/atlas-kubernetes-operator-install.txt
@@ -47,7 +47,7 @@ Options
    * - --configOnly
      - 
      - false
-     - Flag that indicates whether to generate only the operator configuration files without installing the Operator
+     - Flag that indicates whether to generate only the Operator configuration files without installing the Operator
    * - -h, --help
      - 
      - false

--- a/source/command/atlas-kubernetes-operator.txt
+++ b/source/command/atlas-kubernetes-operator.txt
@@ -58,4 +58,5 @@ Related Commands
    :titlesonly:
 
    install </command/atlas-kubernetes-operator-install>
+   dry-run </command/atlas-kubernetes-dry-run>
 

--- a/source/command/atlas-kubernetes.txt
+++ b/source/command/atlas-kubernetes.txt
@@ -40,6 +40,7 @@ Related Commands
 ----------------
 
 * :ref:`atlas-kubernetes-config` - Manage Kubernetes configuration resources.
+* :ref:`atlas-kubernetes-dry-run` - Deploy and run Atlas Kubernetes Operator in dry-run mode
 * :ref:`atlas-kubernetes-operator` - Manage Atlas Kubernetes Operator.
 
 
@@ -47,5 +48,5 @@ Related Commands
    :titlesonly:
 
    config </command/atlas-kubernetes-config>
+   dry-run </command/atlas-kubernetes-dry-run>
    operator </command/atlas-kubernetes-operator>
-

--- a/source/command/atlas-kubernetes.txt
+++ b/source/command/atlas-kubernetes.txt
@@ -48,5 +48,4 @@ Related Commands
    :titlesonly:
 
    config </command/atlas-kubernetes-config>
-   dry-run </command/atlas-kubernetes-dry-run>
    operator </command/atlas-kubernetes-operator>


### PR DESCRIPTION
- [DOCSP-48106](https://jira.mongodb.org/browse/DOCSP-48106)
- [STAGING](https://deploy-preview-948--docs-atlas-cli.netlify.app/command/atlas-kubernetes-dry-run/)

### Self-Review Checklist

- [ ] Check that the submodule pulled in the right changes (if applicable).
- [ ] [Define](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) taxonomy [values](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) at top of page.
- [ ] Add genre facets (tutorial or reference), as in this [example PR](https://github.com/10gen/cloud-docs/pull/5042).
- [ ] Add programmingLanguage (if necessary).
- [ ] Add meta keywords (if necessary).
- [ ] Resolve any new warnings or errors in the build.
- [ ] Proofread for spelling and grammatical errors.
- [ ] Check staging for rendering issues.
- [ ] Confirm links are working.

