### PR TITLE
DOCSP-48588: atlas cli 1.41.1 release notes-v1.41-backport (966)

### DIFF
--- a/source/atlas-cli-changelog.txt
+++ b/source/atlas-cli-changelog.txt
@@ -14,6 +14,16 @@
    :depth: 1
    :class: singlecol
 
+.. _atlas-cli-1.41.1:
+
+{+atlas-cli+} 1.41.1
+--------------------
+
+Released 20 March 2025
+
+- Adds support for two new project settings: ``Data Explorer GenAI Feature`` and ``Data Explorer GenAI Sample Document Passing``.
+- Improves the documentation and the ``--help`` text for the ``atlas api`` commands.
+
 .. _atlas-cli-1.41.0:
 
 {+atlas-cli+} 1.41.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.41`:
 - [DOCSP-48588: atlas cli 1.41.1 release notes (#966)](https://github.com/mongodb/docs-atlas-cli/pull/966)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)