### PR TITLE
add sunset version prompt-v1.29-backport (994)

### DIFF
--- a/.github/prompts/eol-branch.prompt.md
+++ b/.github/prompts/eol-branch.prompt.md
@@ -1,0 +1,54 @@
+<!-- Download and configure Github CLI before running -->
+
+Complete the following tasks:
+
+1. Open the `snooty.toml` file and make the following changes:
+
+- Add `eol = true` to line 3.
+- Add the following code where other banners are located in the file.
+
+```
+[[banners]]
+ targets = ["*"]
+ variant = "info"
+ value = """\
+     This version of the documentation is archived and no longer supported. View the `current documentation <https://www.mongodb.com/docs/atlas/cli/current/>`__ to learn how to `upgrade your version of the Atlas CLI <https://www.mongodb.com/docs/atlas/cli/current/install-atlas-cli/>`__.\
+     """
+```
+
+2. Create a new file named `NoindexEntireSource.sh` that contains the following code:
+
+```
+#!/bin/sh
+while getopts p: flag
+do
+    case "${flag}" in
+        p) project=${OPTARG};;
+    esac
+done
+echo "Adding noindex to all files in $project..."
+# Use find to recursively search for .txt files in the source directory and noindex them
+find ~/"$project"/source -type f -name "*.txt" | while read -r file; do
+    sed -i '' "1s%^%.. meta::\n   :robots: noindex, nosnippet \n\n%" "$file"
+done
+```
+
+4. Run the following command in the terminal: `sh <path-to-bash-script>/NoindexEntireSource.sh -p docs-atlas-cli`, replacing `<path-to-bash-script>` with the path to `NoindexEntireSource.sh`.
+   
+For example: `sh ~/Projects/NoindexEntireSource.sh -p Projects/docs-atlas-cli`
+   
+This script should add the following code to the top of every file in the repo:
+
+```
+.. meta::
+   :robots: noindex, nosnippet 
+```
+
+5. Then, create a PR with these changes by performing the following actions:
+
+- Run `git status`
+- Run `git add -- :!submodules/mongodb-atlas-cli`. This is to add all files to the commit except for the submodules files.
+- Generate a short PR description like "Sunset v1.20" and run `gcmsg "<PR description>"` in the terminal.
+- Generate a descriptive PR title like "Sunset Atlas CLI v1.20" and Run `gh pr create --title "(<current-branch>): <title>" --base <target-base-branch-name>`. Replace the placeholders with appropriate values. The version number is the versioned upstream branch. Ask me if you need clarification.
+- Run `ggp` in the terminal. The user might need to enter their SSH key passphrase. If the push is rejected, walk through the errors with me.
+- Return the link to the PR. It should look like: https://github.com/<github-username>/cloud-docs/pull/new/<current-branch>

--- a/.github/prompts/eol-branch.prompt.md
+++ b/.github/prompts/eol-branch.prompt.md
@@ -1,6 +1,6 @@
 <!-- Download and configure Github CLI before running -->
 
-Complete the following tasks:
+You are an agent that will help sunset a version of our docs. The user will provide the version number (e.g. v1.20). Complete the following tasks:
 
 1. Open the `snooty.toml` file and make the following changes:
 
@@ -33,7 +33,7 @@ find ~/"$project"/source -type f -name "*.txt" | while read -r file; do
 done
 ```
 
-4. Run the following command in the terminal: `sh <path-to-bash-script>/NoindexEntireSource.sh -p docs-atlas-cli`, replacing `<path-to-bash-script>` with the path to `NoindexEntireSource.sh`.
+3. Run the following command in the terminal: `sh <path-to-bash-script>/NoindexEntireSource.sh -p docs-atlas-cli`, replacing `<path-to-bash-script>` with the path to `NoindexEntireSource.sh`.
    
 For example: `sh ~/Projects/NoindexEntireSource.sh -p Projects/docs-atlas-cli`
    
@@ -44,11 +44,11 @@ This script should add the following code to the top of every file in the repo:
    :robots: noindex, nosnippet 
 ```
 
-5. Then, create a PR with these changes by performing the following actions:
+4. Then, create a PR with these changes by performing the following actions:
 
 - Run `git status`
-- Run `git add -- :!submodules/mongodb-atlas-cli`. This is to add all files to the commit except for the submodules files.
+- Run `git add -- ':!submodules/mongodb-atlas-cli'`. This is to add all files to the commit except for the submodules files.
 - Generate a short PR description like "Sunset v1.20" and run `gcmsg "<PR description>"` in the terminal.
-- Generate a descriptive PR title like "Sunset Atlas CLI v1.20" and Run `gh pr create --title "(<current-branch>): <title>" --base <target-base-branch-name>`. Replace the placeholders with appropriate values. The version number is the versioned upstream branch. Ask me if you need clarification.
-- Run `ggp` in the terminal. The user might need to enter their SSH key passphrase. If the push is rejected, walk through the errors with me.
-- Return the link to the PR. It should look like: https://github.com/<github-username>/cloud-docs/pull/new/<current-branch>
+- Generate a descriptive PR title like "Sunset Atlas CLI v1.20" and Run `gh pr create --title "(<current-branch>): <title>" --base <target-base-branch-name>`. Replace the placeholders with appropriate values. Target base branch name example is the version number (e.g. v1.20).
+
+The user will finalize the PR via the terminal prompts.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode/settings.json
 settings.json
+NoindexEntireSource.sh


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.29`:
 - [add sunset version prompt (#994)](https://github.com/mongodb/docs-atlas-cli/pull/994)
 - [update prompt (#1025)](https://github.com/mongodb/docs-atlas-cli/pull/1025)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)