### PR TITLE
(DOCSP-46384) Fix repetitive title in Atlas CLI

### DIFF
--- a/source/command/atlas.txt
+++ b/source/command/atlas.txt
@@ -1,8 +1,8 @@
 .. _atlas:
 
-=====
-atlas
-=====
+====================
+Atlas CLI Reference
+====================
 
 .. meta::
    :description: Manage MongoDB Atlas deployments and search using the Atlas CLI with intuitive terminal commands.
@@ -65,7 +65,7 @@ Related Commands
 * :ref:`atlas-completion` - Generate the autocompletion script for the specified shell
 * :ref:`atlas-config` - Configure and manage your user profiles.
 * :ref:`atlas-customDbRoles` - Manage custom database roles for your project.
-* :ref:`atlas-customDns` - Manage DNS configuration of Atlas project’s clusters deployed to AWS.
+* :ref:`atlas-customDns` - Manage DNS configuration of Atlas project's clusters deployed to AWS.
 * :ref:`atlas-dataFederation` - Data federation.
 * :ref:`atlas-dbusers` - Manage database users for your project.
 * :ref:`atlas-deployments` - Manage cloud and local deployments.


### PR DESCRIPTION
This PR changes the title for one topic, to avoid the following repetitive path that was found by Croud reports for docs Content Maintenance: `https://www.mongodb.com/docs/atlas/cli/current/command/atlas/`


- [DOCSP-46384](https://jira.mongodb.org/browse/DOCSP-46384)
- [STAGING](paste the link to staging here)



