### PR TITLE
DOCSP-50382 Update all preview callouts to link to new preview info page-v1.39-backport (1115)

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -123,3 +123,20 @@ value = """\
     **Data Lake is deprecated.** \
     As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see :adl:`Migration Guide </data-lake-deprecation/>`\
     """
+
+[[banners]]
+targets = ["atlas-cli-admin-api.txt"]
+variant = "warning"
+value = """\
+    {+atlas-cli+} support for running commands with the {+atlas-admin-api+} is in Preview. The feature and the corresponding documentation might change at any time during the Preview period. You can provide feedback on this feature through the `MongoDB Feedback Engine for Atlas CLI <https://feedback.mongodb.com/forums/930808-atlas-cli>`__. To learn more, see `Preview Features <https://www.mongodb.com/docs/preview-features/>`__.\
+    """
+
+# DOCSP-50382
+[[banners]]
+targets = ["command/atlas-api-*.txt",
+           "command/atlas-api.txt"]
+variant = "warning"
+value = """\
+    {+atlas-cli+} support for running commands with the {+atlas-admin-api+} is in Preview. The feature and the corresponding documentation might change at any time during the Preview period. To learn more, see `Preview Features <https://www.mongodb.com/docs/preview-features/>`__.\
+    """
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.39`:
 - [DOCSP-50382 Update all preview callouts to link to new preview info page (#1115)](https://github.com/mongodb/docs-atlas-cli/pull/1115)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)